### PR TITLE
Add LLM-powered analysis to daily summary

### DIFF
--- a/src/HomelabBot/Services/DailySummaryService.cs
+++ b/src/HomelabBot/Services/DailySummaryService.cs
@@ -1,4 +1,6 @@
+using System.Text.Json;
 using HomelabBot.Configuration;
+using HomelabBot.Models;
 using Microsoft.Extensions.Options;
 
 namespace HomelabBot.Services;
@@ -7,17 +9,20 @@ public sealed class DailySummaryService : BackgroundService
 {
     private readonly IOptionsMonitor<DailySummaryConfiguration> _config;
     private readonly SummaryDataAggregator _aggregator;
+    private readonly KernelService _kernelService;
     private readonly DiscordBotService _discordBot;
     private readonly ILogger<DailySummaryService> _logger;
 
     public DailySummaryService(
         IOptionsMonitor<DailySummaryConfiguration> config,
         SummaryDataAggregator aggregator,
+        KernelService kernelService,
         DiscordBotService discordBot,
         ILogger<DailySummaryService> logger)
     {
         _config = config;
         _aggregator = aggregator;
+        _kernelService = kernelService;
         _discordBot = discordBot;
         _logger = logger;
     }
@@ -99,7 +104,8 @@ public sealed class DailySummaryService : BackgroundService
         _logger.LogInformation("Generating daily summary");
 
         var data = await _aggregator.AggregateAsync(ct);
-        var embed = SummaryEmbedBuilder.Build(data);
+        var analysis = await GenerateAnalysisAsync(data);
+        var embed = SummaryEmbedBuilder.Build(data, analysis);
 
         var userId = _config.CurrentValue.DiscordUserId;
         if (userId == 0)
@@ -110,5 +116,39 @@ public sealed class DailySummaryService : BackgroundService
 
         await _discordBot.SendDmAsync(userId, embed);
         _logger.LogInformation("Daily summary delivered to user {UserId}", userId);
+    }
+
+    private async Task<string?> GenerateAnalysisAsync(DailySummaryData data)
+    {
+        try
+        {
+            var prompt = $"""
+                Analyze this homelab status and provide a brief 2-3 sentence summary.
+                Focus on anything noteworthy: issues, warnings, recommendations.
+                If everything looks good, say so briefly.
+                Be concise and direct. No greetings or fluff.
+
+                Data:
+                - Health Score: {data.HealthScore}/100
+                - Alerts (last 24h): {data.Alerts.Count} ({data.Alerts.Count(a => a.Severity == "critical")} critical, {data.Alerts.Count(a => a.Severity == "warning")} warning)
+                {(data.Alerts.Count > 0 ? "  Names: " + string.Join(", ", data.Alerts.Take(5).Select(a => a.Name)) : "")}
+                - Containers: {data.Containers.Count(c => c.State == "running")} running, {data.Containers.Count(c => c.State != "running")} stopped
+                {(data.Containers.Any(c => c.State != "running") ? "  Stopped: " + string.Join(", ", data.Containers.Where(c => c.State != "running").Take(5).Select(c => c.Name)) : "")}
+                - Storage Pools: {string.Join(", ", data.Pools.Select(p => $"{p.Name}: {p.Health} ({p.UsedPercent:F0}%)"))}
+                - Router: {(data.Router != null ? $"CPU {data.Router.CpuPercent:F0}%, Mem {data.Router.MemoryPercent:F0}%, Up {data.Router.Uptime.Days}d" : "unavailable")}
+                - Monitoring: {(data.Monitoring != null ? $"{data.Monitoring.UpTargets}/{data.Monitoring.TotalTargets} targets up" : "unavailable")}
+                """;
+
+            var response = await _kernelService.ProcessMessageAsync(
+                threadId: 0,
+                userMessage: prompt);
+
+            return response.Length > 500 ? response[..500] + "..." : response;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to generate AI analysis");
+            return null;
+        }
     }
 }

--- a/src/HomelabBot/Services/SummaryEmbedBuilder.cs
+++ b/src/HomelabBot/Services/SummaryEmbedBuilder.cs
@@ -5,7 +5,7 @@ namespace HomelabBot.Services;
 
 public static class SummaryEmbedBuilder
 {
-    public static DiscordEmbed Build(DailySummaryData data)
+    public static DiscordEmbed Build(DailySummaryData data, string? analysis = null)
     {
         var color = data.HealthScore switch
         {
@@ -18,6 +18,12 @@ public static class SummaryEmbedBuilder
             .WithTitle("📊 Daily Homelab Summary")
             .WithColor(color)
             .WithTimestamp(data.GeneratedAt);
+
+        // AI Analysis (if provided)
+        if (!string.IsNullOrWhiteSpace(analysis))
+        {
+            builder.WithDescription(analysis);
+        }
 
         // Alerts
         if (data.Alerts.Count > 0)


### PR DESCRIPTION
## Summary
- Adds AI-generated analysis to daily summary embed
- LLM analyzes homelab status and provides 2-3 sentence insights
- Highlights issues, warnings, recommendations

## Changes
- `SummaryEmbedBuilder.Build()` - accepts optional `analysis` parameter
- `DailySummaryService` - injects KernelService, generates analysis
- `HomeLabCommands` - `/summary` command also generates analysis

## Test plan
- [ ] Run `/summary` command - should see analysis in embed description
- [ ] Wait for scheduled summary - should include analysis

🤖 Generated with [Claude Code](https://claude.com/claude-code)