### PR TITLE
Fix claude-code-action beta headers proxy issue

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,6 +34,7 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         env:
           ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_PROXY_URL }}
+          CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS: "1"
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           show_full_output: true


### PR DESCRIPTION
## Summary
- Add `CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS=1` env var to claude workflow
- Fixes `context_management: Extra inputs are not permitted` API error caused by proxy stripping beta headers

## Test plan
- [ ] Merge this PR
- [ ] Rerun Claude Code workflow on PR #26
- [ ] Verify no 400 error

🤖 Generated with [Claude Code](https://claude.com/claude-code)