### PR TITLE
Add Container Log Anomaly Highlights (#8)

### DIFF
--- a/src/HomelabBot/Commands/HomeLabCommands.cs
+++ b/src/HomelabBot/Commands/HomeLabCommands.cs
@@ -10,6 +10,7 @@ public class HomeLabCommands : ApplicationCommandModule
 {
     private readonly DockerPlugin _dockerPlugin;
     private readonly KnowledgePlugin _knowledgePlugin;
+    private readonly LokiPlugin _lokiPlugin;
     private readonly KernelService _kernelService;
     private readonly ConversationService _conversationService;
     private readonly SummaryDataAggregator _summaryAggregator;
@@ -19,6 +20,7 @@ public class HomeLabCommands : ApplicationCommandModule
     public HomeLabCommands(
         DockerPlugin dockerPlugin,
         KnowledgePlugin knowledgePlugin,
+        LokiPlugin lokiPlugin,
         KernelService kernelService,
         ConversationService conversationService,
         SummaryDataAggregator summaryAggregator,
@@ -27,6 +29,7 @@ public class HomeLabCommands : ApplicationCommandModule
     {
         _dockerPlugin = dockerPlugin;
         _knowledgePlugin = knowledgePlugin;
+        _lokiPlugin = lokiPlugin;
         _kernelService = kernelService;
         _conversationService = conversationService;
         _summaryAggregator = summaryAggregator;
@@ -344,6 +347,77 @@ public class HomeLabCommands : ApplicationCommandModule
             _logger.LogError(ex, "Error in health command");
             await ctx.EditResponseAsync(new DiscordWebhookBuilder()
                 .WithContent($"Error getting health score: {ex.Message}"));
+        }
+    }
+
+    [SlashCommand("logs-analyze", "Analyze container logs for errors and anomalies")]
+    public async Task LogsAnalyzeCommand(
+        InteractionContext ctx,
+        [Option("container", "Container name (optional, analyzes all if omitted)")] string? container = null)
+    {
+        await ctx.DeferAsync();
+
+        try
+        {
+            _logger.LogDebug("LogsAnalyze command invoked by {User} for {Container}",
+                ctx.User.Username, container ?? "all");
+
+            var threadId = (ulong)DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+
+            string prompt;
+            if (!string.IsNullOrWhiteSpace(container))
+            {
+                var errors = await _lokiPlugin.CountErrorsByContainer("1h");
+                var logs = await _lokiPlugin.GetContainerLogs(container, "1h");
+
+                // Truncate for token efficiency
+                if (logs.Length > 2000) logs = logs[..2000] + "\n... (truncated)";
+
+                prompt = $"""
+                    Analyze the logs for container "{container}". Here's the data:
+
+                    ERROR COUNTS (last 1h):
+                    {errors}
+
+                    RECENT LOGS:
+                    {logs}
+
+                    Provide a brief analysis: what errors are occurring, likely cause, and suggested action.
+                    Be concise (3-5 sentences max).
+                    """;
+            }
+            else
+            {
+                var errors = await _lokiPlugin.CountErrorsByContainer("1h");
+                var critical = await _lokiPlugin.DetectCriticalPatterns("1h");
+
+                prompt = $"""
+                    Analyze error logs across all containers. Here's the data:
+
+                    ERROR COUNTS BY CONTAINER (last 1h):
+                    {errors}
+
+                    CRITICAL PATTERNS (fatal/panic/OOM):
+                    {critical}
+
+                    Summarize: which containers have issues, severity, likely causes, suggested actions.
+                    Be concise. Focus on what needs attention.
+                    """;
+            }
+
+            var response = await _kernelService.ProcessMessageAsync(
+                threadId, prompt, ctx.User.Id, TraceType.Chat);
+
+            _conversationService.ClearHistory(threadId);
+
+            await EditResponseWithContentOrFileAsync(ctx, response, "log-analysis.md",
+                "Log analysis complete. See attached:");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error in logs-analyze command");
+            await ctx.EditResponseAsync(new DiscordWebhookBuilder()
+                .WithContent($"Error analyzing logs: {ex.Message}"));
         }
     }
 

--- a/src/HomelabBot/Configuration/BotConfiguration.cs
+++ b/src/HomelabBot/Configuration/BotConfiguration.cs
@@ -101,6 +101,16 @@ public sealed class AlertWebhookConfiguration
     public ulong DiscordUserId { get; init; }
 }
 
+public sealed class LogAnomalyConfiguration
+{
+    public const string SectionName = "LogAnomaly";
+
+    public bool Enabled { get; init; } = true;
+    public int IntervalMinutes { get; init; } = 30;
+    public int ErrorThreshold { get; init; } = 50;
+    public ulong DiscordUserId { get; init; }
+}
+
 public sealed class HealthScoreConfiguration
 {
     public const string SectionName = "HealthScore";

--- a/src/HomelabBot/Plugins/LokiPlugin.cs
+++ b/src/HomelabBot/Plugins/LokiPlugin.cs
@@ -276,6 +276,159 @@ public sealed class LokiPlugin
         return $"No logs found for container '{containerName}' in the last {since}. Try using ListLabels and ListLabelValues to discover available labels.";
     }
 
+    public async Task<Dictionary<string, long>> GetErrorCountsByContainerAsync(string since = "1h")
+    {
+        var normalizedSince = NormalizeDuration(since);
+        var query = $"sum by (compose_service) (count_over_time({{job=~\".+\"}} |~ \"(?i)(\\\\berror\\\\b|\\\\bexception\\\\b|\\\\bfailed\\\\b|\\\\bfailure\\\\b)\" [{normalizedSince}]))";
+
+        var encodedQuery = Uri.EscapeDataString(query);
+        var url = $"{_baseUrl}/loki/api/v1/query?query={encodedQuery}";
+        var response = await _httpClient.GetAsync(url);
+        response.EnsureSuccessStatusCode();
+
+        var result = await response.Content.ReadFromJsonAsync<LokiQueryResponse>();
+        var entries = new Dictionary<string, long>();
+
+        if (result?.Data?.Result == null)
+            return entries;
+
+        foreach (var stream in result.Data.Result)
+        {
+            var container = stream.Stream?.GetValueOrDefault("compose_service") ?? "unknown";
+            long count = 0;
+
+            if (stream.Values is { Count: > 0 } && stream.Values[0].Length >= 2)
+            {
+                long.TryParse(stream.Values[0][1].ToString(), out count);
+            }
+            else if (stream.Value is { Length: >= 2 })
+            {
+                long.TryParse(stream.Value[1].ToString(), out count);
+            }
+
+            if (count > 0)
+                entries[container] = count;
+        }
+
+        return entries;
+    }
+
+    [KernelFunction]
+    [Description("Counts error/exception log lines per container over a time window. Returns container name and error count.")]
+    public async Task<string> CountErrorsByContainer(
+        [Description("Time range like '1h', '6h', '24h' (default 1h)")] string since = "1h")
+    {
+        _logger.LogDebug("Counting errors by container since {Since}", since);
+
+        try
+        {
+            var entries = await GetErrorCountsByContainerAsync(since);
+
+            if (entries.Count == 0)
+            {
+                return $"No error logs found in the last {since}.";
+            }
+
+            var sb = new StringBuilder();
+            sb.AppendLine($"**Error counts by container** (last {since}):\n");
+
+            foreach (var entry in entries.OrderByDescending(e => e.Value))
+            {
+                var emoji = entry.Value > 100 ? "🔴" : entry.Value > 10 ? "🟡" : "🟢";
+                sb.AppendLine($"{emoji} **{entry.Key}**: {entry.Value} errors");
+            }
+
+            sb.AppendLine($"\nTotal: {entries.Values.Sum()} errors across {entries.Count} containers");
+
+            return sb.ToString();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error counting errors by container");
+            return $"Error counting errors: {ex.Message}";
+        }
+    }
+
+    [KernelFunction]
+    [Description("Detects critical log patterns (fatal, panic, OOM, segfault, killed) across all containers.")]
+    public async Task<string> DetectCriticalPatterns(
+        [Description("Time range like '1h', '6h', '24h' (default 1h)")] string since = "1h")
+    {
+        _logger.LogDebug("Detecting critical patterns since {Since}", since);
+
+        var duration = ParseDuration(since);
+        var query = "{job=~\".+\"} |~ \"(?i)(fatal|panic|oom|out of memory|killed process|segfault)\"";
+        var now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() * 1_000_000;
+        var start = DateTimeOffset.UtcNow.Subtract(duration).ToUnixTimeMilliseconds() * 1_000_000;
+
+        try
+        {
+            var encodedQuery = Uri.EscapeDataString(query);
+            var url = $"{_baseUrl}/loki/api/v1/query_range?query={encodedQuery}&start={start}&end={now}&limit=50";
+            var response = await _httpClient.GetAsync(url);
+            response.EnsureSuccessStatusCode();
+
+            var result = await response.Content.ReadFromJsonAsync<LokiQueryResponse>();
+
+            if (result?.Data?.Result == null || result.Data.Result.Count == 0)
+            {
+                return $"No critical patterns (fatal/panic/OOM/segfault) found in the last {since}.";
+            }
+
+            var sb = new StringBuilder();
+            sb.AppendLine($"**Critical patterns detected** (last {since}):\n");
+
+            var allEvents = new List<(DateTime Timestamp, string Container, string Message)>();
+
+            foreach (var stream in result.Data.Result)
+            {
+                var container = stream.Stream?.GetValueOrDefault("compose_service")
+                    ?? stream.Stream?.GetValueOrDefault("container_name")
+                    ?? "unknown";
+
+                if (stream.Values != null)
+                {
+                    foreach (var value in stream.Values)
+                    {
+                        if (value.Length >= 2)
+                        {
+                            var timestamp = ParseNanoseconds(value[0].ToString() ?? "0");
+                            var message = value[1].ToString() ?? "";
+                            allEvents.Add((timestamp, container, message));
+                        }
+                    }
+                }
+            }
+
+            var grouped = allEvents
+                .GroupBy(e => e.Container)
+                .OrderByDescending(g => g.Count());
+
+            foreach (var group in grouped)
+            {
+                sb.AppendLine($"🔴 **{group.Key}** ({group.Count()} events):");
+                foreach (var evt in group.OrderByDescending(e => e.Timestamp).Take(3))
+                {
+                    var time = evt.Timestamp.ToString("HH:mm:ss");
+                    var msg = evt.Message.Length > 120 ? evt.Message[..117] + "..." : evt.Message;
+                    sb.AppendLine($"  `{time}` {msg}");
+                }
+
+                if (group.Count() > 3)
+                {
+                    sb.AppendLine($"  ... and {group.Count() - 3} more");
+                }
+            }
+
+            return sb.ToString();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error detecting critical patterns");
+            return $"Error detecting critical patterns: {ex.Message}";
+        }
+    }
+
     [KernelFunction]
     [Description("Searches all logs for specific text (grep-style search).")]
     public async Task<string> SearchLogs(
@@ -357,6 +510,18 @@ public sealed class LokiPlugin
         }
     }
 
+    private static string NormalizeDuration(string input)
+    {
+        var duration = ParseDuration(input);
+        var totalMinutes = (int)duration.TotalMinutes;
+        return totalMinutes switch
+        {
+            < 60 => $"{totalMinutes}m",
+            < 1440 => $"{totalMinutes / 60}h",
+            _ => $"{totalMinutes / 1440}d"
+        };
+    }
+
     private static string FormatLabels(Dictionary<string, string>? labels)
     {
         if (labels == null || labels.Count == 0)
@@ -416,6 +581,7 @@ public sealed class LokiPlugin
     {
         public Dictionary<string, string>? Stream { get; set; }
         public List<JsonElement[]>? Values { get; set; }
+        public JsonElement[]? Value { get; set; }
     }
 
     private sealed class LokiLabelsResponse

--- a/src/HomelabBot/Program.cs
+++ b/src/HomelabBot/Program.cs
@@ -71,6 +71,9 @@ try
     builder.Services.AddOptions<HealthScoreConfiguration>()
         .Bind(builder.Configuration.GetSection(HealthScoreConfiguration.SectionName));
 
+    builder.Services.AddOptions<LogAnomalyConfiguration>()
+        .Bind(builder.Configuration.GetSection(LogAnomalyConfiguration.SectionName));
+
     builder.Services.AddOptions<KnowledgeRefreshConfiguration>()
         .Bind(builder.Configuration.GetSection(KnowledgeRefreshConfiguration.SectionName));
 
@@ -143,6 +146,7 @@ try
     builder.Services.AddHostedService<DailySummaryService>();
     builder.Services.AddSingleton<AlertWebhookService>();
     builder.Services.AddHostedService<HealthScoreBackgroundService>();
+    builder.Services.AddHostedService<LogAnomalyService>();
     builder.Services.AddHostedService<KnowledgeRefreshService>();
 
     // API Controllers

--- a/src/HomelabBot/Services/HealthcheckPrompts.cs
+++ b/src/HomelabBot/Services/HealthcheckPrompts.cs
@@ -68,8 +68,8 @@ internal static class HealthcheckPrompts
         Flag: any scrape target DOWN, Loki dropping logs, cardinality >500k.
 
         ### 9. LOKI LOG ANALYSIS (last 24h)
-        - Error logs per container
-        - Fatal/panic/OOM events
+        - Call CountErrorsByContainer("24h") to get error counts per container
+        - Call DetectCriticalPatterns("24h") to find fatal/panic/OOM events
         Flag: any container with >100 error lines/24h, any fatal/panic/OOM.
 
         ### 10. SERVICES — SPECIFIC CHECKS

--- a/src/HomelabBot/Services/LogAnomalyService.cs
+++ b/src/HomelabBot/Services/LogAnomalyService.cs
@@ -1,0 +1,150 @@
+using HomelabBot.Configuration;
+using HomelabBot.Plugins;
+using Microsoft.Extensions.Options;
+
+namespace HomelabBot.Services;
+
+public sealed class LogAnomalyService : BackgroundService
+{
+    private readonly IOptionsMonitor<LogAnomalyConfiguration> _config;
+    private readonly LokiPlugin _lokiPlugin;
+    private readonly KernelService _kernelService;
+    private readonly ConversationService _conversationService;
+    private readonly DiscordBotService _discordBot;
+    private readonly ILogger<LogAnomalyService> _logger;
+    private readonly Dictionary<string, long> _lastKnownErrorCounts = new();
+    private bool _firstRun = true;
+
+    public LogAnomalyService(
+        IOptionsMonitor<LogAnomalyConfiguration> config,
+        LokiPlugin lokiPlugin,
+        KernelService kernelService,
+        ConversationService conversationService,
+        DiscordBotService discordBot,
+        ILogger<LogAnomalyService> logger)
+    {
+        _config = config;
+        _lokiPlugin = lokiPlugin;
+        _kernelService = kernelService;
+        _conversationService = conversationService;
+        _discordBot = discordBot;
+        _logger = logger;
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("Log anomaly service started, waiting for Discord...");
+        await _discordBot.WaitForReadyAsync(stoppingToken);
+        _logger.LogInformation("Discord ready, log anomaly detection running");
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                if (!_config.CurrentValue.Enabled)
+                {
+                    _logger.LogDebug("Log anomaly detection disabled, rechecking in 1 minute");
+                    await Task.Delay(TimeSpan.FromMinutes(1), stoppingToken);
+                    continue;
+                }
+
+                var intervalMinutes = Math.Max(1, _config.CurrentValue.IntervalMinutes);
+                await Task.Delay(TimeSpan.FromMinutes(intervalMinutes), stoppingToken);
+
+                await ScanForAnomaliesAsync(stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Error in log anomaly service");
+                await Task.Delay(TimeSpan.FromMinutes(5), stoppingToken);
+            }
+        }
+    }
+
+    private async Task ScanForAnomaliesAsync(CancellationToken ct)
+    {
+        var isFirstRun = _firstRun;
+        _firstRun = false;
+
+        var errorCounts = await _lokiPlugin.GetErrorCountsByContainerAsync("1h");
+        var criticalPatterns = await _lokiPlugin.DetectCriticalPatterns("1h");
+
+        var hasCritical = !criticalPatterns.Contains("No critical patterns");
+        var newSpikes = DetectErrorSpikes(errorCounts);
+
+        if (!hasCritical && newSpikes.Count == 0)
+        {
+            _logger.LogDebug("No log anomalies detected");
+            return;
+        }
+
+        // Skip notifications on first run (baseline)
+        if (isFirstRun)
+        {
+            _logger.LogInformation("First anomaly scan complete, baseline established");
+            return;
+        }
+
+        var userId = _config.CurrentValue.DiscordUserId;
+        if (userId == 0)
+            return;
+
+        if (hasCritical)
+        {
+            await NotifyAsync(userId, $"🔴 **Critical Log Patterns Detected**\n{TruncateForDiscord(criticalPatterns)}");
+        }
+
+        if (newSpikes.Count > 0)
+        {
+            var spikeText = string.Join("\n", newSpikes.Select(s => $"• **{s.Container}**: {s.PreviousCount} → {s.CurrentCount} errors/h"));
+            await NotifyAsync(userId, $"📈 **Error Rate Spikes Detected**\n{spikeText}");
+        }
+    }
+
+    private List<ErrorSpike> DetectErrorSpikes(Dictionary<string, long> errorCounts)
+    {
+        var spikes = new List<ErrorSpike>();
+        var threshold = _config.CurrentValue.ErrorThreshold;
+
+        foreach (var (container, count) in errorCounts)
+        {
+            var previousCount = _lastKnownErrorCounts.GetValueOrDefault(container, 0);
+            _lastKnownErrorCounts[container] = count;
+
+            if (count >= threshold && count > previousCount * 2 && previousCount > 0)
+            {
+                spikes.Add(new ErrorSpike { Container = container, PreviousCount = previousCount, CurrentCount = count });
+            }
+        }
+
+        return spikes;
+    }
+
+    private async Task NotifyAsync(ulong userId, string message)
+    {
+        try
+        {
+            await _discordBot.SendDmAsync(userId, message);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to send log anomaly notification");
+        }
+    }
+
+    private static string TruncateForDiscord(string text)
+    {
+        return text.Length > 1800 ? text[..1797] + "..." : text;
+    }
+
+    private sealed class ErrorSpike
+    {
+        public required string Container { get; init; }
+        public required long PreviousCount { get; init; }
+        public required long CurrentCount { get; init; }
+    }
+}

--- a/src/HomelabBot/appsettings.json
+++ b/src/HomelabBot/appsettings.json
@@ -86,6 +86,12 @@
     "AlertDropThreshold": 15,
     "DiscordUserId": 170921674840080384
   },
+  "LogAnomaly": {
+    "Enabled": true,
+    "IntervalMinutes": 30,
+    "ErrorThreshold": 50,
+    "DiscordUserId": 170921674840080384
+  },
   "KnowledgeRefresh": {
     "Enabled": true,
     "ScheduleTime": "03:00",


### PR DESCRIPTION
## Summary
- Add `CountErrorsByContainer` and `DetectCriticalPatterns` KernelFunctions to LokiPlugin
- Add `/logs-analyze` slash command — optional container param, LLM-driven analysis
- Background `LogAnomalyService` scans every 30min, notifies on error rate spikes and critical patterns (fatal/panic/OOM)
- Update healthcheck prompts section 9 to use new Loki functions
- Structured data flow: `GetErrorCountsByContainerAsync()` returns `Dictionary<string, long>` for both display and background service
- Input sanitization via `NormalizeDuration`, word-boundary regex to avoid false positives

## Test plan
- [ ] `/logs-analyze` shows error summary across all containers
- [ ] `/logs-analyze container:traefik` shows per-container LLM analysis
- [ ] Background service scans and logs "No log anomalies detected" when clean
- [ ] First scan establishes baseline without notifications
- [ ] Error spike (>2x previous + above threshold) triggers Discord DM
- [ ] Critical patterns (OOM/fatal/panic) trigger Discord DM
- [ ] Daily healthcheck section 9 now uses real Loki data

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)