### PR TITLE
Add conversation memory with /recall command (#31)

### DIFF
--- a/src/HomelabBot/Commands/HomeLabCommands.cs
+++ b/src/HomelabBot/Commands/HomeLabCommands.cs
@@ -479,6 +479,58 @@ public class HomeLabCommands : ApplicationCommandModule
         }
     }
 
+    [SlashCommand("recall", "Search past conversations for context on an issue")]
+    public async Task RecallCommand(
+        InteractionContext ctx,
+        [Option("query", "What to search for (e.g. 'Plex crashed', 'high CPU', 'TLS cert')")] string query)
+    {
+        await ctx.DeferAsync();
+
+        var threadId = (ulong)DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+
+        try
+        {
+            _logger.LogDebug("Recall command invoked by {User} for '{Query}'", ctx.User.Username, query);
+
+            var results = await _conversationService.SearchConversationsAsync(query);
+
+            if (results.Count == 0)
+            {
+                await ctx.EditResponseAsync(new DiscordWebhookBuilder()
+                    .WithContent($"No past conversations found matching \"{query}\"."));
+                return;
+            }
+
+            var formattedResults = ConversationSearchResult.FormatResults(results, previewMaxLength: 200);
+
+            var prompt = $"""
+                The user is searching their conversation history for: "{query}"
+
+                Here are the relevant past conversations:
+                {formattedResults}
+
+                Summarize what was discussed, what actions were taken, and what the outcome was.
+                Focus on practical info the user can act on now. Be concise.
+                """;
+
+            var response = await _kernelService.ProcessMessageAsync(
+                threadId, prompt, ctx.User.Id, TraceType.Chat);
+
+            await EditResponseWithContentOrFileAsync(ctx, response, "recall.md",
+                $"Recall results for \"{query}\":");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error in recall command");
+            await ctx.EditResponseAsync(new DiscordWebhookBuilder()
+                .WithContent($"Error searching conversations: {ex.Message}"));
+        }
+        finally
+        {
+            _conversationService.ClearHistory(threadId);
+        }
+    }
+
     [SlashCommand("roast", "Roast your homelab")]
     public async Task RoastCommand(InteractionContext ctx)
     {

--- a/src/HomelabBot/Models/ConversationSearchResult.cs
+++ b/src/HomelabBot/Models/ConversationSearchResult.cs
@@ -1,0 +1,55 @@
+using System.Text;
+using HomelabBot.Data.Entities;
+
+namespace HomelabBot.Models;
+
+public sealed class ConversationSearchResult
+{
+    public required int ConversationId { get; init; }
+    public required ulong ThreadId { get; init; }
+    public string? Title { get; init; }
+    public required DateTime Date { get; init; }
+    public required int Score { get; init; }
+    public required List<ConversationMessage> RelevantMessages { get; init; }
+
+    public string TimeAgo
+    {
+        get
+        {
+            var age = DateTime.UtcNow - Date;
+            return age.TotalDays > 1 ? $"{(int)age.TotalDays}d ago" : $"{(int)age.TotalHours}h ago";
+        }
+    }
+
+    public string DisplayTitle => Title ?? "Untitled";
+
+    public static string FormatResults(
+        IReadOnlyList<ConversationSearchResult> results, int previewMaxLength = 150)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"Found {results.Count} relevant conversation(s):\n");
+
+        foreach (var r in results)
+        {
+            sb.AppendLine($"**[{r.TimeAgo}] {r.DisplayTitle}**");
+
+            foreach (var msg in r.RelevantMessages)
+            {
+                var preview = Truncate(msg.Content, previewMaxLength);
+                sb.AppendLine($"  {msg.Role}: {preview}");
+            }
+
+            sb.AppendLine();
+        }
+
+        return sb.ToString();
+    }
+
+    public static string Truncate(string text, int maxLength)
+    {
+        if (maxLength < 4 || text.Length <= maxLength)
+            return text;
+
+        return text[.. (maxLength - 3)] + "...";
+    }
+}

--- a/src/HomelabBot/Plugins/InvestigationPlugin.cs
+++ b/src/HomelabBot/Plugins/InvestigationPlugin.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.Text;
+using HomelabBot.Models;
 using HomelabBot.Services;
 using Microsoft.SemanticKernel;
 
@@ -8,14 +9,19 @@ namespace HomelabBot.Plugins;
 public sealed class InvestigationPlugin
 {
     private readonly MemoryService _memoryService;
+    private readonly ConversationService _conversationService;
     private readonly ILogger<InvestigationPlugin> _logger;
 
     // Track current investigation per thread (in-memory for quick access)
     private readonly Dictionary<ulong, int> _activeInvestigations = new();
 
-    public InvestigationPlugin(MemoryService memoryService, ILogger<InvestigationPlugin> logger)
+    public InvestigationPlugin(
+        MemoryService memoryService,
+        ConversationService conversationService,
+        ILogger<InvestigationPlugin> logger)
     {
         _memoryService = memoryService;
+        _conversationService = conversationService;
         _logger = logger;
     }
 
@@ -48,9 +54,23 @@ public sealed class InvestigationPlugin
         {
             sb.AppendLine(pastContext);
         }
-        else
+
+        // Search past conversations for additional context
+        var conversationResults = await _conversationService.SearchConversationsAsync(symptom, limit: 3);
+        if (conversationResults.Count > 0)
         {
-            sb.AppendLine("No similar past incidents found.");
+            sb.AppendLine("\n### Relevant Past Conversations");
+            foreach (var r in conversationResults)
+            {
+                sb.AppendLine($"- [{r.TimeAgo}] {r.DisplayTitle}");
+                if (r.RelevantMessages.Count > 0)
+                    sb.AppendLine($"  > {ConversationSearchResult.Truncate(r.RelevantMessages[0].Content, 100)}");
+            }
+        }
+
+        if (string.IsNullOrEmpty(pastContext) && conversationResults.Count == 0)
+        {
+            sb.AppendLine("No similar past incidents or conversations found.");
         }
 
         sb.AppendLine("\nUse RecordStep() to log each diagnostic action.");
@@ -163,6 +183,21 @@ public sealed class InvestigationPlugin
         }
 
         return sb.ToString();
+    }
+
+    [KernelFunction]
+    [Description("Search past conversations for context on an issue. Use this to find what was discussed or done previously about a topic.")]
+    public async Task<string> SearchConversations(
+        [Description("Keywords to search for (e.g. 'Plex crashed', 'high CPU', 'TLS cert')")] string query)
+    {
+        _logger.LogDebug("Searching conversations for '{Query}'", query);
+
+        var results = await _conversationService.SearchConversationsAsync(query);
+
+        if (results.Count == 0)
+            return $"No past conversations found matching '{query}'.";
+
+        return ConversationSearchResult.FormatResults(results);
     }
 
     [KernelFunction]

--- a/src/HomelabBot/Services/ConversationService.cs
+++ b/src/HomelabBot/Services/ConversationService.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using HomelabBot.Data;
 using HomelabBot.Data.Entities;
+using HomelabBot.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.SemanticKernel.ChatCompletion;
 
@@ -124,6 +125,54 @@ public sealed class ConversationService
             conversation.Title = title;
             await db.SaveChangesAsync(ct);
         }
+    }
+
+    public async Task<List<ConversationSearchResult>> SearchConversationsAsync(
+        string query, int limit = 5, CancellationToken ct = default)
+    {
+        await using var db = await _dbFactory.CreateDbContextAsync(ct);
+
+        var keywords = query
+            .Split(' ', StringSplitOptions.RemoveEmptyEntries)
+            .Where(k => k.Length > 1)
+            .ToArray();
+
+        if (keywords.Length == 0)
+            return [];
+
+        var conversations = await db.Conversations
+            .AsNoTracking()
+            .Include(c => c.Messages)
+            .Where(c => c.Messages.Count > 0)
+            .OrderByDescending(c => c.LastMessageAt)
+            .Take(100)
+            .ToListAsync(ct);
+
+        return conversations
+            .Select(c =>
+            {
+                var score = keywords.Count(k =>
+                    c.Messages.Any(m => m.Content.Contains(k, StringComparison.OrdinalIgnoreCase)));
+                return (Conversation: c, Score: score);
+            })
+            .Where(x => x.Score > 0)
+            .OrderByDescending(x => x.Score)
+            .ThenByDescending(x => x.Conversation.LastMessageAt)
+            .Take(limit)
+            .Select(x => new ConversationSearchResult
+            {
+                ConversationId = x.Conversation.Id,
+                ThreadId = x.Conversation.ThreadId,
+                Title = x.Conversation.Title,
+                Date = x.Conversation.LastMessageAt ?? x.Conversation.CreatedAt,
+                Score = x.Score,
+                RelevantMessages = x.Conversation.Messages
+                    .Where(m => keywords.Any(k => m.Content.Contains(k, StringComparison.OrdinalIgnoreCase)))
+                    .OrderBy(m => m.Timestamp)
+                    .Take(5)
+                    .ToList(),
+            })
+            .ToList();
     }
 
     public void ClearHistory(ulong threadId)


### PR DESCRIPTION
## Summary
- `SearchConversationsAsync` on ConversationService: keyword search across past conversations with per-message matching (no string concatenation), AsNoTracking
- `/recall` slash command: searches conversation history, LLM summarizes findings
- `SearchConversations` KernelFunction on InvestigationPlugin: LLM can search past conversations during any chat
- Auto-context in `StartInvestigation`: searches past conversations alongside existing pattern matching
- Shared `ConversationSearchResult` model with `TimeAgo`, `DisplayTitle`, `FormatResults`, `Truncate` helpers
- No new entities or migrations — queries existing Conversations/ConversationMessages tables

## Test plan
- [ ] `/recall "high CPU"` returns LLM summary of past conversations mentioning CPU
- [ ] `/recall "nonexistent"` returns "No past conversations found"
- [ ] Short queries like "VM" or "HA" work (min keyword length = 2)
- [ ] StartInvestigation shows relevant past conversations in context
- [ ] LLM can call SearchConversations during normal chat
- [ ] ClearHistory runs even on error (finally block)

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)