### PR TITLE
Consolidate DiscordUserId into HomelabOwner constant

### DIFF
--- a/src/HomelabBot/Configuration/BotConfiguration.cs
+++ b/src/HomelabBot/Configuration/BotConfiguration.cs
@@ -1,5 +1,14 @@
 namespace HomelabBot.Configuration;
 
+/// <summary>
+/// Single-user homelab bot — the owner's Discord ID is hardcoded here
+/// rather than duplicated across every feature config section.
+/// </summary>
+public static class HomelabOwner
+{
+    public const ulong DiscordUserId = 170921674840080384;
+}
+
 public sealed class BotConfiguration
 {
     public const string SectionName = "Bot";
@@ -91,14 +100,11 @@ public sealed class DailySummaryConfiguration
     public bool Enabled { get; init; } = false;
     public string ScheduleTime { get; init; } = "08:00";
     public string TimeZone { get; init; } = "Europe/Warsaw";
-    public ulong DiscordUserId { get; init; }
 }
 
 public sealed class AlertWebhookConfiguration
 {
     public const string SectionName = "AlertWebhook";
-
-    public ulong DiscordUserId { get; init; }
 }
 
 public sealed class AnomalyDetectionConfiguration
@@ -108,7 +114,6 @@ public sealed class AnomalyDetectionConfiguration
     public bool Enabled { get; init; } = true;
     public int HeuristicIntervalMinutes { get; init; } = 60;
     public int LlmIntervalTicks { get; init; } = 1;
-    public ulong DiscordUserId { get; init; }
 }
 
 public sealed class SecurityAuditConfiguration
@@ -119,7 +124,6 @@ public sealed class SecurityAuditConfiguration
     public DayOfWeek ScheduleDay { get; init; } = DayOfWeek.Sunday;
     public string ScheduleTime { get; init; } = "02:00";
     public string TimeZone { get; init; } = "Europe/Warsaw";
-    public ulong DiscordUserId { get; init; }
 }
 
 public sealed class LogAnomalyConfiguration
@@ -129,7 +133,6 @@ public sealed class LogAnomalyConfiguration
     public bool Enabled { get; init; } = true;
     public int IntervalMinutes { get; init; } = 30;
     public int ErrorThreshold { get; init; } = 50;
-    public ulong DiscordUserId { get; init; }
 }
 
 public sealed class HealthScoreConfiguration
@@ -139,7 +142,6 @@ public sealed class HealthScoreConfiguration
     public bool Enabled { get; init; } = true;
     public int IntervalMinutes { get; init; } = 15;
     public int AlertDropThreshold { get; init; } = 15;
-    public ulong DiscordUserId { get; init; }
     public int CriticalAlertWeight { get; init; } = 20;
     public int WarningAlertWeight { get; init; } = 5;
     public int StoppedContainerWeight { get; init; } = 10;
@@ -159,5 +161,4 @@ public sealed class KnowledgeRefreshConfiguration
     public string ScheduleTime { get; init; } = "03:00";
     public string TimeZone { get; init; } = "Europe/Warsaw";
     public bool NotifyOnChanges { get; init; } = false;
-    public ulong DiscordUserId { get; init; }
 }

--- a/src/HomelabBot/Services/AlertWebhookService.cs
+++ b/src/HomelabBot/Services/AlertWebhookService.cs
@@ -39,12 +39,6 @@ public sealed class AlertWebhookService
 
     public async Task ProcessAlertsAsync(AlertmanagerWebhookPayload payload, CancellationToken ct = default)
     {
-        if (_config.DiscordUserId == 0)
-        {
-            _logger.LogWarning("AlertWebhook: DiscordUserId not configured, skipping");
-            return;
-        }
-
         _logger.LogInformation("Processing {Count} alerts from Alertmanager", payload.Alerts.Count);
 
         foreach (var alert in payload.Alerts)
@@ -75,7 +69,7 @@ public sealed class AlertWebhookService
             if (runbookResult != null)
             {
                 var runbookEmbed = BuildAlertEmbed(alert, runbookResult);
-                await _discordService.SendDmAsync(_config.DiscordUserId, runbookEmbed);
+                await _discordService.SendDmAsync(HomelabOwner.DiscordUserId, runbookEmbed);
                 return;
             }
 
@@ -111,7 +105,7 @@ public sealed class AlertWebhookService
             analysis = await _kernelService.ProcessMessageAsync(
                 conversationId,
                 prompt,
-                _config.DiscordUserId,
+                HomelabOwner.DiscordUserId,
                 TraceType.Scheduled,
                 ct: ct);
         }
@@ -125,13 +119,13 @@ public sealed class AlertWebhookService
         if (matchedPatterns.Count > 0)
         {
             await _discordService.SendDmWithComponentsAsync(
-                _config.DiscordUserId,
+                HomelabOwner.DiscordUserId,
                 embed,
                 BuildPatternFeedbackButtons(matchedPatterns));
         }
         else
         {
-            await _discordService.SendDmAsync(_config.DiscordUserId, embed);
+            await _discordService.SendDmAsync(HomelabOwner.DiscordUserId, embed);
         }
     }
 

--- a/src/HomelabBot/Services/AnomalyDetectionService.cs
+++ b/src/HomelabBot/Services/AnomalyDetectionService.cs
@@ -266,7 +266,7 @@ public sealed class AnomalyDetectionService : BackgroundService
 
     private async Task RunLlmAnalysisAsync(List<Anomaly> anomalies, CancellationToken ct)
     {
-        var userId = _config.CurrentValue.DiscordUserId;
+        var userId = HomelabOwner.DiscordUserId;
         if (userId == 0)
             return;
 
@@ -326,7 +326,7 @@ public sealed class AnomalyDetectionService : BackgroundService
 
     private async Task NotifyCriticalAnomaliesAsync(List<Anomaly> anomalies, CancellationToken ct)
     {
-        var userId = _config.CurrentValue.DiscordUserId;
+        var userId = HomelabOwner.DiscordUserId;
         if (userId == 0)
             return;
 

--- a/src/HomelabBot/Services/DailySummaryService.cs
+++ b/src/HomelabBot/Services/DailySummaryService.cs
@@ -96,7 +96,7 @@ public sealed class DailySummaryService : BackgroundService
     {
         _logger.LogInformation("Starting daily healthcheck investigation");
 
-        var userId = _config.CurrentValue.DiscordUserId;
+        var userId = HomelabOwner.DiscordUserId;
         if (userId == 0)
         {
             _logger.LogWarning("DiscordUserId not configured, cannot send DM");

--- a/src/HomelabBot/Services/HealthScoreBackgroundService.cs
+++ b/src/HomelabBot/Services/HealthScoreBackgroundService.cs
@@ -75,7 +75,7 @@ public sealed class HealthScoreBackgroundService : BackgroundService
 
         if (previousScore.HasValue && previousScore.Value - result.Score >= threshold)
         {
-            var userId = _config.CurrentValue.DiscordUserId;
+            var userId = HomelabOwner.DiscordUserId;
             if (userId == 0)
                 return;
 

--- a/src/HomelabBot/Services/KnowledgeRefreshService.cs
+++ b/src/HomelabBot/Services/KnowledgeRefreshService.cs
@@ -125,7 +125,7 @@ public sealed class KnowledgeRefreshService : BackgroundService
             "Knowledge refresh complete: {Added} added, {Verified} verified, {Stale} stale, {Errors} errors",
             result.AddedFacts, result.VerifiedFacts, result.StaleFacts, result.Errors.Count);
 
-        if (_config.CurrentValue.NotifyOnChanges && _config.CurrentValue.DiscordUserId != 0
+        if (_config.CurrentValue.NotifyOnChanges && HomelabOwner.DiscordUserId != 0
             && (result.AddedFacts > 0 || result.StaleFacts > 0))
         {
             await SendNotificationAsync(result);
@@ -285,7 +285,7 @@ public sealed class KnowledgeRefreshService : BackgroundService
 
         try
         {
-            await _discordBot.SendDmAsync(_config.CurrentValue.DiscordUserId, message);
+            await _discordBot.SendDmAsync(HomelabOwner.DiscordUserId, message);
         }
         catch (Exception ex)
         {

--- a/src/HomelabBot/Services/LogAnomalyService.cs
+++ b/src/HomelabBot/Services/LogAnomalyService.cs
@@ -89,7 +89,7 @@ public sealed class LogAnomalyService : BackgroundService
             return;
         }
 
-        var userId = _config.CurrentValue.DiscordUserId;
+        var userId = HomelabOwner.DiscordUserId;
         if (userId == 0)
             return;
 

--- a/src/HomelabBot/Services/SecurityAuditService.cs
+++ b/src/HomelabBot/Services/SecurityAuditService.cs
@@ -87,7 +87,7 @@ public sealed class SecurityAuditService : BackgroundService
     {
         _logger.LogInformation("Starting scheduled security audit");
 
-        var userId = _config.CurrentValue.DiscordUserId;
+        var userId = HomelabOwner.DiscordUserId;
         if (userId == 0)
         {
             _logger.LogWarning("DiscordUserId not configured, cannot send security audit");

--- a/src/HomelabBot/appsettings.json
+++ b/src/HomelabBot/appsettings.json
@@ -74,42 +74,35 @@
   "DailySummary": {
     "Enabled": true,
     "ScheduleTime": "08:00",
-    "TimeZone": "Europe/Warsaw",
-    "DiscordUserId": 170921674840080384
+    "TimeZone": "Europe/Warsaw"
   },
-  "AlertWebhook": {
-    "DiscordUserId": 170921674840080384
-  },
+  "AlertWebhook": {},
   "HealthScore": {
     "Enabled": true,
     "IntervalMinutes": 15,
-    "AlertDropThreshold": 15,
-    "DiscordUserId": 170921674840080384
+    "AlertDropThreshold": 15
   },
   "AnomalyDetection": {
     "Enabled": true,
     "HeuristicIntervalMinutes": 60,
-    "LlmIntervalTicks": 1,
-    "DiscordUserId": 170921674840080384
+    "LlmIntervalTicks": 1
   },
   "SecurityAudit": {
     "Enabled": true,
     "ScheduleDay": "Sunday",
     "ScheduleTime": "02:00",
-    "TimeZone": "Europe/Warsaw",
-    "DiscordUserId": 170921674840080384
+    "TimeZone": "Europe/Warsaw"
   },
   "LogAnomaly": {
     "Enabled": true,
     "IntervalMinutes": 30,
-    "ErrorThreshold": 50,
-    "DiscordUserId": 170921674840080384
+    "ErrorThreshold": 50
   },
   "KnowledgeRefresh": {
     "Enabled": true,
     "ScheduleTime": "03:00",
     "TimeZone": "Europe/Warsaw",
-    "NotifyOnChanges": true,
-    "DiscordUserId": 170921674840080384
+    "NotifyOnChanges": true
+
   }
 }


### PR DESCRIPTION
## Summary
- Add `HomelabOwner.DiscordUserId` constant in BotConfiguration.cs
- Remove `DiscordUserId` property from 7 config classes (DailySummary, AlertWebhook, AnomalyDetection, SecurityAudit, LogAnomaly, HealthScore, KnowledgeRefresh)
- Remove 7 duplicate `DiscordUserId` entries from appsettings.json
- Replace all `_config.DiscordUserId` / `_config.CurrentValue.DiscordUserId` with `HomelabOwner.DiscordUserId`
- Comment explains this is a single-user homelab bot

Net: -12 lines, one source of truth for owner ID.

## Test plan
- [ ] Bot starts and all services resolve the owner ID correctly
- [ ] DM notifications still work (healthcheck, alerts, anomalies, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)