### PR TITLE
Add smart notification system with DM conversation support

### DIFF
--- a/src/HomelabBot/Models/NotificationCandidate.cs
+++ b/src/HomelabBot/Models/NotificationCandidate.cs
@@ -1,0 +1,18 @@
+namespace HomelabBot.Models;
+
+public sealed class NotificationCandidate
+{
+    public required string Source { get; init; }
+
+    public required string Summary { get; init; }
+
+    public required string RawData { get; init; }
+
+    public string? IssueType { get; init; }
+
+    /// <summary>
+    /// If true, RawData already contains a fully investigated report.
+    /// The LLM will only decide whether to notify, not re-investigate.
+    /// </summary>
+    public bool AlreadyInvestigated { get; init; }
+}

--- a/src/HomelabBot/Models/NotificationCandidate.cs
+++ b/src/HomelabBot/Models/NotificationCandidate.cs
@@ -15,4 +15,11 @@ public sealed class NotificationCandidate
     /// The LLM will only decide whether to notify, not re-investigate.
     /// </summary>
     public bool AlreadyInvestigated { get; init; }
+
+    /// <summary>
+    /// If true, this candidate cannot be hard-suppressed by notification preferences.
+    /// It will always reach the LLM for evaluation (preferences are still in the prompt).
+    /// Use for critical issues that should never be silently dropped.
+    /// </summary>
+    public bool NeverSuppress { get; init; }
 }

--- a/src/HomelabBot/Program.cs
+++ b/src/HomelabBot/Program.cs
@@ -175,6 +175,7 @@ try
     builder.Services.AddSingleton<HealthScoreService>();
     builder.Services.AddSingleton<ServiceStateStore>();
     builder.Services.AddSingleton<SummaryDataAggregator>();
+    builder.Services.AddSingleton<SmartNotificationService>();
     builder.Services.AddHostedService<DailySummaryService>();
     builder.Services.AddSingleton<AutoRemediationService>();
     builder.Services.AddSingleton<HealingChainService>();

--- a/src/HomelabBot/Services/AnomalyDetectionService.cs
+++ b/src/HomelabBot/Services/AnomalyDetectionService.cs
@@ -85,7 +85,9 @@ public sealed class AnomalyDetectionService : BackgroundService
                 var anomalies = await RunHeuristicChecksAsync(stoppingToken);
                 await PersistBaselineAsync();
 
-                if (anomalies.Count > 0)
+                // Only evaluate via LLM every N ticks to avoid excessive API calls
+                var llmInterval = Math.Max(1, _config.CurrentValue.LlmIntervalTicks);
+                if (anomalies.Count > 0 && _heuristicTick % llmInterval == 0)
                 {
                     await NotifyAnomaliesAsync(anomalies, stoppingToken);
                 }

--- a/src/HomelabBot/Services/AnomalyDetectionService.cs
+++ b/src/HomelabBot/Services/AnomalyDetectionService.cs
@@ -85,9 +85,11 @@ public sealed class AnomalyDetectionService : BackgroundService
                 var anomalies = await RunHeuristicChecksAsync(stoppingToken);
                 await PersistBaselineAsync();
 
-                // Only evaluate via LLM every N ticks to avoid excessive API calls
+                // Evaluate via LLM every N ticks, but critical anomalies bypass throttle
                 var llmInterval = Math.Max(1, _config.CurrentValue.LlmIntervalTicks);
-                if (anomalies.Count > 0 && _heuristicTick % llmInterval == 0)
+                if (anomalies.Count > 0
+                    && (_heuristicTick % llmInterval == 0
+                        || anomalies.Any(a => a.Severity == AnomalySeverity.Critical)))
                 {
                     await NotifyAnomaliesAsync(anomalies, stoppingToken);
                 }

--- a/src/HomelabBot/Services/AnomalyDetectionService.cs
+++ b/src/HomelabBot/Services/AnomalyDetectionService.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using HomelabBot.Configuration;
 using HomelabBot.Data;
 using HomelabBot.Data.Entities;
+using HomelabBot.Models;
 using HomelabBot.Plugins;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
@@ -14,8 +15,7 @@ public sealed class AnomalyDetectionService : BackgroundService
     private readonly IOptionsMonitor<AnomalyDetectionConfiguration> _config;
     private readonly HttpClient _httpClient;
     private readonly string _prometheusUrl;
-    private readonly KernelService _kernelService;
-    private readonly ConversationService _conversationService;
+    private readonly SmartNotificationService _smartNotification;
     private readonly DiscordBotService _discordBot;
     private readonly IDbContextFactory<HomelabDbContext> _dbFactory;
     private readonly ILogger<AnomalyDetectionService> _logger;
@@ -34,8 +34,7 @@ public sealed class AnomalyDetectionService : BackgroundService
         IOptionsMonitor<AnomalyDetectionConfiguration> config,
         IHttpClientFactory httpClientFactory,
         IOptions<PrometheusConfiguration> prometheusConfig,
-        KernelService kernelService,
-        ConversationService conversationService,
+        SmartNotificationService smartNotification,
         DiscordBotService discordBot,
         IDbContextFactory<HomelabDbContext> dbFactory,
         ILogger<AnomalyDetectionService> logger,
@@ -47,8 +46,7 @@ public sealed class AnomalyDetectionService : BackgroundService
         _config = config;
         _httpClient = httpClientFactory.CreateClient("Default");
         _prometheusUrl = prometheusConfig.Value.Host.TrimEnd('/');
-        _kernelService = kernelService;
-        _conversationService = conversationService;
+        _smartNotification = smartNotification;
         _discordBot = discordBot;
         _dbFactory = dbFactory;
         _logger = logger;
@@ -87,16 +85,9 @@ public sealed class AnomalyDetectionService : BackgroundService
                 var anomalies = await RunHeuristicChecksAsync(stoppingToken);
                 await PersistBaselineAsync();
 
-                // Every N heuristic ticks, run LLM analysis if anomalies detected
-                var llmInterval = Math.Max(1, _config.CurrentValue.LlmIntervalTicks);
-                if (_heuristicTick % llmInterval == 0 && anomalies.Count > 0)
+                if (anomalies.Count > 0)
                 {
-                    await RunLlmAnalysisAsync(anomalies, stoppingToken);
-                }
-                else if (anomalies.Any(a => a.Severity == AnomalySeverity.Critical))
-                {
-                    // Critical anomalies always trigger immediate notification
-                    await NotifyCriticalAnomaliesAsync(anomalies, stoppingToken);
+                    await NotifyAnomaliesAsync(anomalies, stoppingToken);
                 }
             }
             catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
@@ -605,81 +596,33 @@ public sealed class AnomalyDetectionService : BackgroundService
         return anomalies;
     }
 
-    private async Task RunLlmAnalysisAsync(List<Anomaly> anomalies, CancellationToken ct)
+    private async Task NotifyAnomaliesAsync(List<Anomaly> anomalies, CancellationToken ct)
     {
-        var userId = HomelabOwner.DiscordUserId;
-        if (userId == 0)
-        {
-            return;
-        }
-
         var anomalySummary = new StringBuilder();
-        anomalySummary.AppendLine("The following anomalies were detected by automated monitoring:");
         foreach (var a in anomalies)
         {
             var emoji = a.Severity == AnomalySeverity.Critical ? "🔴" : "🟡";
             anomalySummary.AppendLine($"{emoji} [{a.Type}] {a.Message}");
         }
 
-        var threadId = (ulong)DateTimeOffset.UtcNow.ToUnixTimeSeconds();
-        try
-        {
-            var prompt = $"""
-                PROACTIVE MONITORING ALERT - Analyze these anomalies:
+        var hasCritical = anomalies.Any(a => a.Severity == AnomalySeverity.Critical);
+        var issueType = hasCritical ? "critical_anomaly" : "anomaly_detection";
+        var summary = hasCritical
+            ? $"{anomalies.Count(a => a.Severity == AnomalySeverity.Critical)} critical anomalies detected"
+            : $"{anomalies.Count} anomalies detected by heuristic monitoring";
 
-                {anomalySummary}
-
-                Use your tools to investigate the root cause. Check related metrics, logs, and container states.
-                Provide a brief analysis with:
-                1. What's happening
-                2. Likely cause
-                3. Recommended action
-                Be concise (3-5 sentences).
-                """;
-
-            var analysis = await _kernelService.ProcessMessageAsync(
-                threadId, prompt, traceType: TraceType.Scheduled, ct: ct);
-
-            var message = $"🔍 **Proactive Anomaly Detection**\n\n{anomalySummary}\n**Analysis:**\n{analysis}";
-
-            try
+        await _smartNotification.EvaluateAndNotifyAsync(
+            new NotificationCandidate
             {
-                await _discordBot.SendDmSplitAsync(userId, message);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "Failed to send anomaly notification");
-            }
+                Source = "anomaly_detection",
+                Summary = summary,
+                RawData = anomalySummary.ToString(),
+                IssueType = issueType,
+            },
+            ct);
 
-            // Record anomaly event
-            await RecordAnomalyEventAsync(anomalies, analysis, ct);
-        }
-        finally
-        {
-            _conversationService.ClearHistory(threadId);
-        }
-    }
-
-    private async Task NotifyCriticalAnomaliesAsync(List<Anomaly> anomalies, CancellationToken ct)
-    {
-        var userId = HomelabOwner.DiscordUserId;
-        if (userId == 0)
-        {
-            return;
-        }
-
-        var criticals = anomalies.Where(a => a.Severity == AnomalySeverity.Critical).ToList();
-        var message = $"🚨 **Critical Anomalies Detected**\n\n" +
-                      string.Join("\n", criticals.Select(a => $"🔴 [{a.Type}] {a.Message}"));
-
-        try
-        {
-            await _discordBot.SendDmAsync(userId, message);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Failed to send critical anomaly notification");
-        }
+        // Record anomaly event (without LLM analysis — that's now done by SmartNotificationService)
+        await RecordAnomalyEventAsync(anomalies, "Routed to smart notification service", ct);
     }
 
     private async Task RecordAnomalyEventAsync(List<Anomaly> anomalies, string analysis, CancellationToken ct)

--- a/src/HomelabBot/Services/AnomalyDetectionService.cs
+++ b/src/HomelabBot/Services/AnomalyDetectionService.cs
@@ -622,6 +622,7 @@ public sealed class AnomalyDetectionService : BackgroundService
                 Summary = summary,
                 RawData = anomalySummary.ToString(),
                 IssueType = issueType,
+                NeverSuppress = hasCritical,
             },
             ct);
 

--- a/src/HomelabBot/Services/DailySummaryService.cs
+++ b/src/HomelabBot/Services/DailySummaryService.cs
@@ -1,4 +1,5 @@
 using HomelabBot.Configuration;
+using HomelabBot.Models;
 using Microsoft.Extensions.Options;
 
 namespace HomelabBot.Services;
@@ -7,20 +8,20 @@ public sealed class DailySummaryService : BackgroundService
 {
     private readonly IOptionsMonitor<DailySummaryConfiguration> _config;
     private readonly KernelService _kernelService;
-    private readonly ConversationService _conversationService;
+    private readonly SmartNotificationService _smartNotification;
     private readonly DiscordBotService _discordBot;
     private readonly ILogger<DailySummaryService> _logger;
 
     public DailySummaryService(
         IOptionsMonitor<DailySummaryConfiguration> config,
         KernelService kernelService,
-        ConversationService conversationService,
+        SmartNotificationService smartNotification,
         DiscordBotService discordBot,
         ILogger<DailySummaryService> logger)
     {
         _config = config;
         _kernelService = kernelService;
-        _conversationService = conversationService;
+        _smartNotification = smartNotification;
         _discordBot = discordBot;
         _logger = logger;
     }
@@ -47,7 +48,7 @@ public sealed class DailySummaryService : BackgroundService
 
                 await Task.Delay(delay, stoppingToken);
 
-                await GenerateAndDeliverHealthcheckAsync(stoppingToken);
+                await RunHealthcheckCycleAsync(stoppingToken);
             }
             catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
             {
@@ -97,22 +98,18 @@ public sealed class DailySummaryService : BackgroundService
         return nextRunUtc - nowUtc;
     }
 
-    private async Task GenerateAndDeliverHealthcheckAsync(CancellationToken ct)
+    private async Task RunHealthcheckCycleAsync(CancellationToken ct)
     {
-        _logger.LogInformation("Starting daily healthcheck investigation");
+        _logger.LogInformation("Starting daily healthcheck cycle");
 
-        var userId = HomelabOwner.DiscordUserId;
-        if (userId == 0)
-        {
-            _logger.LogWarning("DiscordUserId not configured, cannot send DM");
-            return;
-        }
+        // Start a new notification cycle (learns from previous day, clears old context)
+        await _smartNotification.StartNewCycleAsync(ct);
 
-        // Use a unique thread ID to avoid conversation history buildup
-        var threadId = (ulong)DateTimeOffset.UtcNow.ToUnixTimeSeconds();
-
+        // Run the full healthcheck investigation and route through smart notification
         try
         {
+            var threadId = _smartNotification.CurrentDailyThreadId;
+
             var report = await _kernelService.ProcessMessageAsync(
                 threadId: threadId,
                 userMessage: HealthcheckPrompts.Investigation,
@@ -121,18 +118,23 @@ public sealed class DailySummaryService : BackgroundService
                 systemPromptOverride: HealthcheckPrompts.System,
                 ct: ct);
 
-            await _discordBot.SendDmSplitAsync(userId, report);
+            // Route through smart notification — it will decide whether to notify
+            await _smartNotification.EvaluateAndNotifyAsync(
+                new NotificationCandidate
+                {
+                    Source = "daily_healthcheck",
+                    Summary = "Daily healthcheck completed. Review the findings below.",
+                    RawData = report,
+                    IssueType = "daily_healthcheck",
+                    AlreadyInvestigated = true,
+                },
+                ct);
 
-            _logger.LogInformation("Daily healthcheck delivered to user {UserId}", userId);
+            _logger.LogInformation("Daily healthcheck cycle completed");
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to generate daily healthcheck");
-        }
-        finally
-        {
-            // Clean up ephemeral conversation history to prevent memory leak
-            _conversationService.ClearHistory(threadId);
+            _logger.LogError(ex, "Failed to run daily healthcheck");
         }
     }
 }

--- a/src/HomelabBot/Services/DiscordBotService.cs
+++ b/src/HomelabBot/Services/DiscordBotService.cs
@@ -457,7 +457,7 @@ public sealed class DiscordBotService : BackgroundService
         catch (Exception ex)
         {
             _logger.LogError(ex, "Error handling DM message");
-            await e.Channel.SendMessageAsync($"Something went wrong: {ex.Message}");
+            await e.Channel.SendMessageAsync("Something went wrong while processing your message. Please try again later.");
         }
     }
 

--- a/src/HomelabBot/Services/DiscordBotService.cs
+++ b/src/HomelabBot/Services/DiscordBotService.cs
@@ -4,6 +4,7 @@ using DSharpPlus.EventArgs;
 using DSharpPlus.SlashCommands;
 using HomelabBot.Commands;
 using HomelabBot.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 
 namespace HomelabBot.Services;
@@ -18,6 +19,7 @@ public sealed class DiscordBotService : BackgroundService
     private readonly MemoryService _memoryService;
     private readonly AutoRemediationService _autoRemediationService;
     private readonly IServiceProvider _serviceProvider;
+    private readonly Lazy<SmartNotificationService> _smartNotification;
     private DiscordClient? _client;
     private SlashCommandsExtension? _slashCommands;
     private int _reconnectAttempts;
@@ -42,7 +44,11 @@ public sealed class DiscordBotService : BackgroundService
         _memoryService = memoryService;
         _autoRemediationService = autoRemediationService;
         _serviceProvider = serviceProvider;
+        _smartNotification = new Lazy<SmartNotificationService>(
+            () => _serviceProvider.GetRequiredService<SmartNotificationService>());
     }
+
+    private SmartNotificationService SmartNotification => _smartNotification.Value;
 
     public Task WaitForReadyAsync(CancellationToken ct = default)
     {
@@ -86,7 +92,8 @@ public sealed class DiscordBotService : BackgroundService
             TokenType = TokenType.Bot,
             Intents = DiscordIntents.AllUnprivileged |
                       DiscordIntents.MessageContents |
-                      DiscordIntents.GuildMessages,
+                      DiscordIntents.GuildMessages |
+                      DiscordIntents.DirectMessages,
             AutoReconnect = true
         };
 
@@ -144,6 +151,13 @@ public sealed class DiscordBotService : BackgroundService
                 return;
             }
 
+            if (customId.StartsWith(SmartNotificationService.ButtonPrefixNormal)
+                || customId.StartsWith(SmartNotificationService.ButtonPrefixInvestigate))
+            {
+                await HandleNotificationFeedbackAsync(e);
+                return;
+            }
+
             if (customId.StartsWith("remediation_approve_") || customId.StartsWith("remediation_reject_")
                 || customId.StartsWith("remediation_ok_") || customId.StartsWith("remediation_fail_"))
             {
@@ -198,6 +212,53 @@ public sealed class DiscordBotService : BackgroundService
             new DiscordInteractionResponseBuilder()
                 .WithContent($"{emoji} {text}")
                 .AsEphemeral());
+    }
+
+    private async Task HandleNotificationFeedbackAsync(ComponentInteractionCreateEventArgs e)
+    {
+        var customId = e.Interaction.Data.CustomId;
+        var isSuppress = customId.StartsWith(SmartNotificationService.ButtonPrefixNormal);
+        var prefix = isSuppress ? SmartNotificationService.ButtonPrefixNormal : SmartNotificationService.ButtonPrefixInvestigate;
+        var hash = customId[prefix.Length..];
+
+        try
+        {
+            if (isSuppress)
+            {
+                await SmartNotification.HandleSuppressFeedbackAsync(
+                    hash, "Marked as normal via button feedback");
+
+                await e.Interaction.CreateResponseAsync(
+                    InteractionResponseType.ChannelMessageWithSource,
+                    new DiscordInteractionResponseBuilder()
+                        .WithContent("✅ Got it, I'll suppress similar notifications in the future.")
+                        .AsEphemeral());
+            }
+            else
+            {
+                await e.Interaction.CreateResponseAsync(
+                    InteractionResponseType.ChannelMessageWithSource,
+                    new DiscordInteractionResponseBuilder()
+                        .WithContent("🔍 Noted. Feel free to ask me follow-up questions about this issue.")
+                        .AsEphemeral());
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to handle notification feedback");
+            try
+            {
+                await e.Interaction.CreateResponseAsync(
+                    InteractionResponseType.ChannelMessageWithSource,
+                    new DiscordInteractionResponseBuilder()
+                        .WithContent("Something went wrong processing your feedback.")
+                        .AsEphemeral());
+            }
+            catch
+            {
+                // Already responded or timed out
+            }
+        }
     }
 
     private async Task HandleRemediationResponseAsync(ComponentInteractionCreateEventArgs e)
@@ -294,6 +355,13 @@ public sealed class DiscordBotService : BackgroundService
             return;
         }
 
+        // Handle DM conversations from the owner
+        if (e.Channel.IsPrivate && e.Author.Id == HomelabOwner.DiscordUserId)
+        {
+            await HandleDmMessageAsync(e);
+            return;
+        }
+
         // Check if we should respond
         var isMentioned = e.Message.MentionedUsers.Any(u => u.Id == client.CurrentUser.Id);
         var isDedicatedChannel = _config.DedicatedChannels.Contains(e.Channel.Id);
@@ -364,56 +432,51 @@ public sealed class DiscordBotService : BackgroundService
         }
     }
 
-    private static async Task SendResponseAsync(DiscordChannel channel, string response)
+    private async Task HandleDmMessageAsync(MessageCreateEventArgs e)
     {
-        const int maxLength = 2000;
-
-        if (response.Length <= maxLength)
+        var content = e.Message.Content.Trim();
+        if (string.IsNullOrWhiteSpace(content))
         {
-            await channel.SendMessageAsync(response);
             return;
         }
 
-        // Split into chunks
-        var chunks = SplitMessage(response, maxLength);
-        foreach (var chunk in chunks)
+        var threadId = SmartNotification.CurrentDailyThreadId;
+        SmartNotification.MarkConversationActive();
+
+        _logger.LogDebug("Processing DM from owner, using daily cycle threadId={ThreadId}", threadId);
+
+        try
         {
-            await channel.SendMessageAsync(chunk);
-            await Task.Delay(100); // Small delay between messages
+            await e.Channel.TriggerTypingAsync();
+
+            var response = await _kernelService.ProcessMessageAsync(
+                threadId, content, e.Author.Id);
+
+            await SendToChannelSplitAsync(e.Channel, response);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error handling DM message");
+            await e.Channel.SendMessageAsync($"Something went wrong: {ex.Message}");
         }
     }
 
-    private static List<string> SplitMessage(string message, int maxLength)
+    private static async Task SendResponseAsync(DiscordChannel channel, string response)
     {
-        var chunks = new List<string>();
-        var remaining = message;
+        await SendToChannelSplitAsync(channel, response);
+    }
 
-        while (remaining.Length > maxLength)
+    private static async Task SendToChannelSplitAsync(DiscordChannel channel, string content)
+    {
+        var chunks = MessageSplitService.SplitIntoSections(content);
+        foreach (var chunk in chunks)
         {
-            // Try to split at a newline
-            var splitIndex = remaining.LastIndexOf('\n', maxLength - 1);
-            if (splitIndex <= 0)
+            await channel.SendMessageAsync(chunk);
+            if (chunks.Count > 1)
             {
-                // No newline found, split at space
-                splitIndex = remaining.LastIndexOf(' ', maxLength - 1);
+                await Task.Delay(100);
             }
-
-            if (splitIndex <= 0)
-            {
-                // No space found, hard split
-                splitIndex = maxLength;
-            }
-
-            chunks.Add(remaining[..splitIndex]);
-            remaining = remaining[splitIndex..].TrimStart();
         }
-
-        if (!string.IsNullOrEmpty(remaining))
-        {
-            chunks.Add(remaining);
-        }
-
-        return chunks;
     }
 
     private static TimeSpan GetBackoffDelay(int attempt)
@@ -473,6 +536,29 @@ public sealed class DiscordBotService : BackgroundService
                 await Task.Delay(100); // Small delay between messages
             }
         }
+    }
+
+    public async Task SendDmNotificationFeedbackAsync(ulong userId, string issueHash)
+    {
+        var dm = await GetDmChannelAsync(userId);
+        if (dm == null)
+        {
+            return;
+        }
+
+        var builder = new DiscordMessageBuilder()
+            .WithContent("Was this notification useful?")
+            .AddComponents(
+                new DiscordButtonComponent(
+                    ButtonStyle.Secondary,
+                    $"{SmartNotificationService.ButtonPrefixNormal}{issueHash}",
+                    "Normal, ignore in future"),
+                new DiscordButtonComponent(
+                    ButtonStyle.Primary,
+                    $"{SmartNotificationService.ButtonPrefixInvestigate}{issueHash}",
+                    "Investigate further"));
+
+        await dm.SendMessageAsync(builder);
     }
 
     public async Task<(ulong ThreadId, ulong MessageId)?> CreateThreadInChannelAsync(

--- a/src/HomelabBot/Services/HealthScoreBackgroundService.cs
+++ b/src/HomelabBot/Services/HealthScoreBackgroundService.cs
@@ -1,4 +1,5 @@
 using HomelabBot.Configuration;
+using HomelabBot.Models;
 using Microsoft.Extensions.Options;
 
 namespace HomelabBot.Services;
@@ -8,6 +9,7 @@ public sealed class HealthScoreBackgroundService : BackgroundService
     private readonly IOptionsMonitor<HealthScoreConfiguration> _config;
     private readonly SummaryDataAggregator _aggregator;
     private readonly HealthScoreService _healthScoreService;
+    private readonly SmartNotificationService _smartNotification;
     private readonly DiscordBotService _discordBot;
     private readonly ILogger<HealthScoreBackgroundService> _logger;
     private int? _lastNotifiedScore;
@@ -16,12 +18,14 @@ public sealed class HealthScoreBackgroundService : BackgroundService
         IOptionsMonitor<HealthScoreConfiguration> config,
         SummaryDataAggregator aggregator,
         HealthScoreService healthScoreService,
+        SmartNotificationService smartNotification,
         DiscordBotService discordBot,
         ILogger<HealthScoreBackgroundService> logger)
     {
         _config = config;
         _aggregator = aggregator;
         _healthScoreService = healthScoreService;
+        _smartNotification = smartNotification;
         _discordBot = discordBot;
         _logger = logger;
     }
@@ -80,24 +84,21 @@ public sealed class HealthScoreBackgroundService : BackgroundService
         if (previousScore.HasValue && previousScore.Value - result.Score >= threshold
             && (_lastNotifiedScore == null || result.Score < _lastNotifiedScore))
         {
-            var userId = HomelabOwner.DiscordUserId;
-            if (userId == 0)
-            {
-                return;
-            }
+            var rawData = $"Score: {previousScore.Value} → {result.Score} in the last hour\n{BuildBreakdown(result)}";
 
-            var message = $"⚠️ **Health Score Drop Detected**\n" +
-                          $"Score went from **{previousScore.Value}** → **{result.Score}** in the last hour\n" +
-                          BuildBreakdown(result);
+            var notified = await _smartNotification.EvaluateAndNotifyAsync(
+                new NotificationCandidate
+                {
+                    Source = "health_score",
+                    Summary = $"Health score dropped {previousScore.Value - result.Score} points ({previousScore.Value} → {result.Score})",
+                    RawData = rawData,
+                    IssueType = "health_score_drop",
+                },
+                ct);
 
-            try
+            if (notified)
             {
-                await _discordBot.SendDmAsync(userId, message);
                 _lastNotifiedScore = result.Score;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "Failed to send health score drop DM");
             }
 
             _logger.LogWarning("Health score dropped {Points} points: {Old} → {New}",

--- a/src/HomelabBot/Services/HealthcheckPrompts.cs
+++ b/src/HomelabBot/Services/HealthcheckPrompts.cs
@@ -119,6 +119,7 @@ internal static class HealthcheckPrompts
         - NO markdown tables, NO headers with ###, NO horizontal rules
         - Keep it scannable in 10 seconds
         - STAY UNDER 1800 CHARACTERS — count carefully
+        - If everything looks healthy with no actionable findings, you can produce a minimal report
         """;
 
     internal const int MaxTokens = 2048;

--- a/src/HomelabBot/Services/LogAnomalyService.cs
+++ b/src/HomelabBot/Services/LogAnomalyService.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using HomelabBot.Configuration;
+using HomelabBot.Models;
 using HomelabBot.Plugins;
 using Microsoft.Extensions.Options;
 
@@ -9,8 +10,7 @@ public sealed class LogAnomalyService : BackgroundService
 {
     private readonly IOptionsMonitor<LogAnomalyConfiguration> _config;
     private readonly LokiPlugin _lokiPlugin;
-    private readonly KernelService _kernelService;
-    private readonly ConversationService _conversationService;
+    private readonly SmartNotificationService _smartNotification;
     private readonly DiscordBotService _discordBot;
     private readonly ILogger<LogAnomalyService> _logger;
     private readonly ServiceStateStore _stateStore;
@@ -20,16 +20,14 @@ public sealed class LogAnomalyService : BackgroundService
     public LogAnomalyService(
         IOptionsMonitor<LogAnomalyConfiguration> config,
         LokiPlugin lokiPlugin,
-        KernelService kernelService,
-        ConversationService conversationService,
+        SmartNotificationService smartNotification,
         DiscordBotService discordBot,
         ILogger<LogAnomalyService> logger,
         ServiceStateStore stateStore)
     {
         _config = config;
         _lokiPlugin = lokiPlugin;
-        _kernelService = kernelService;
-        _conversationService = conversationService;
+        _smartNotification = smartNotification;
         _discordBot = discordBot;
         _logger = logger;
         _stateStore = stateStore;
@@ -95,22 +93,35 @@ public sealed class LogAnomalyService : BackgroundService
             return;
         }
 
-        var userId = HomelabOwner.DiscordUserId;
-        if (userId == 0)
-        {
-            return;
-        }
+        var sb = new System.Text.StringBuilder();
+        var summaryParts = new List<string>();
 
         if (hasCritical)
         {
-            await NotifyAsync(userId, $"🔴 **Critical Log Patterns Detected**\n{TruncateForDiscord(criticalPatterns)}");
+            summaryParts.Add("critical log patterns (fatal/panic/OOM/segfault)");
+            sb.AppendLine("Critical patterns:");
+            sb.AppendLine(TruncateForDiscord(criticalPatterns));
         }
 
         if (newSpikes.Count > 0)
         {
-            var spikeText = string.Join("\n", newSpikes.Select(s => $"• **{s.Container}**: {s.PreviousCount} → {s.CurrentCount} errors/h"));
-            await NotifyAsync(userId, $"📈 **Error Rate Spikes Detected**\n{spikeText}");
+            summaryParts.Add($"{newSpikes.Count} error rate spike(s)");
+            sb.AppendLine("Error rate spikes:");
+            foreach (var s in newSpikes)
+            {
+                sb.AppendLine($"• {s.Container}: {s.PreviousCount} → {s.CurrentCount} errors/h");
+            }
         }
+
+        await _smartNotification.EvaluateAndNotifyAsync(
+            new NotificationCandidate
+            {
+                Source = "log_anomaly",
+                Summary = $"Log anomalies detected: {string.Join(", ", summaryParts)}",
+                RawData = sb.ToString(),
+                IssueType = hasCritical ? "critical_log_patterns" : "error_rate_spike",
+            },
+            ct);
     }
 
     internal List<ErrorSpike> DetectErrorSpikes(Dictionary<string, long> errorCounts)
@@ -130,18 +141,6 @@ public sealed class LogAnomalyService : BackgroundService
         }
 
         return spikes;
-    }
-
-    private async Task NotifyAsync(ulong userId, string message)
-    {
-        try
-        {
-            await _discordBot.SendDmAsync(userId, message);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex, "Failed to send log anomaly notification");
-        }
     }
 
     private static string TruncateForDiscord(string text)

--- a/src/HomelabBot/Services/LogAnomalyService.cs
+++ b/src/HomelabBot/Services/LogAnomalyService.cs
@@ -120,6 +120,7 @@ public sealed class LogAnomalyService : BackgroundService
                 Summary = $"Log anomalies detected: {string.Join(", ", summaryParts)}",
                 RawData = sb.ToString(),
                 IssueType = hasCritical ? "critical_log_patterns" : "error_rate_spike",
+                NeverSuppress = hasCritical,
             },
             ct);
     }

--- a/src/HomelabBot/Services/NotificationPrompts.cs
+++ b/src/HomelabBot/Services/NotificationPrompts.cs
@@ -1,0 +1,94 @@
+namespace HomelabBot.Services;
+
+internal static class NotificationPrompts
+{
+    internal const string InvestigationSystem = """
+        You are a homelab infrastructure analyst investigating a potential issue.
+        Use the available tools to investigate root causes — query logs, metrics, container states, and any relevant data.
+        Be thorough but concise. Your goal is to determine if this issue is actionable and worth notifying the owner about.
+        """;
+
+    internal const string EndOfCycleLearning = """
+        Review the conversation above from today's notification cycle.
+        Extract notification preference updates based on the owner's responses:
+
+        1. Issues the owner dismissed as unimportant (e.g., "this is fine", "don't worry about this", ignored after investigating)
+        2. Issues the owner explicitly wants to always be notified about
+        3. Any other notification preferences expressed
+
+        For each preference, output a line in this exact format:
+        SUPPRESS: <issue type> — <reason>
+        ALWAYS: <issue type> — <reason>
+
+        If no clear preferences were expressed, output:
+        NO_UPDATES
+
+        Be conservative — only extract preferences that were clearly expressed or strongly implied by the conversation.
+        """;
+
+    internal const string TagNotify = "[NOTIFY]";
+    internal const string TagSilent = "[SILENT]";
+    internal const string TagNoUpdates = "NO_UPDATES";
+    internal const int MaxTokens = 4096;
+
+    internal static string BuildDecisionOnlyPrompt(string summary, string rawData, string preferences)
+    {
+        return $"""
+            An automated healthcheck produced the following report:
+
+            {rawData}
+
+            {(string.IsNullOrWhiteSpace(preferences) ? "" : $"""
+            The owner has these notification preferences:
+            {preferences}
+
+            Respect suppressed issue types unless the situation has clearly escalated beyond what was previously dismissed.
+            """)}
+
+            Based on this report, decide if the owner should be notified.
+            Do NOT use any tools — the investigation is already complete.
+
+            Notify if: there are actionable findings, degraded services, warnings, or anything the owner should act on.
+            Stay silent if: everything is healthy, no actionable findings, all-clear status.
+
+            Respond with ONLY one of these tags on its own line:
+            [NOTIFY] — if the owner should be notified (the report above will be sent as-is)
+            [SILENT] — if this is not worth a notification
+            """;
+    }
+
+    internal static string BuildInvestigationPrompt(string summary, string rawData, string preferences)
+    {
+        return $"""
+            An automated monitor detected the following:
+
+            {summary}
+
+            Raw data:
+            {rawData}
+
+            {(string.IsNullOrWhiteSpace(preferences) ? "" : $"""
+            The owner has these notification preferences:
+            {preferences}
+
+            Respect suppressed issue types unless the situation has clearly escalated beyond what was previously dismissed.
+            """)}
+
+            INSTRUCTIONS:
+            1. Use your tools to investigate this finding. Check related logs, metrics, and container states.
+            2. Determine the root cause or likely explanation.
+            3. Decide if this is worth notifying the owner about:
+               - YES if: actionable problem, degraded service, data loss risk, something the owner should know
+               - NO if: transient blip that resolved, known benign behavior, matches a suppressed preference
+            4. End your response with exactly one of these tags on its own line:
+               [NOTIFY] — if the owner should be notified
+               [SILENT] — if this is not worth a notification
+
+            If [NOTIFY], write a concise report (under 1500 chars) with:
+            - What was detected
+            - What you found during investigation (root cause / context)
+            - Recommended action if any
+            Use emoji severity indicators (🔴 critical, 🟡 warning, 🔵 info).
+            """;
+    }
+}

--- a/src/HomelabBot/Services/SmartNotificationService.cs
+++ b/src/HomelabBot/Services/SmartNotificationService.cs
@@ -209,15 +209,12 @@ public sealed class SmartNotificationService
 
         try
         {
-            var learningThreadId = (ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
             var analysis = await _kernelService.ProcessMessageAsync(
-                threadId: learningThreadId,
+                threadId: threadId,
                 userMessage: NotificationPrompts.EndOfCycleLearning,
                 traceType: TraceType.Scheduled,
                 maxTokens: 1024,
                 ct: ct);
-
-            _conversationService.ClearHistory(learningThreadId);
 
             if (analysis.Contains(NotificationPrompts.TagNoUpdates, StringComparison.OrdinalIgnoreCase))
             {

--- a/src/HomelabBot/Services/SmartNotificationService.cs
+++ b/src/HomelabBot/Services/SmartNotificationService.cs
@@ -51,23 +51,8 @@ public sealed class SmartNotificationService
         {
             lock (_cycleLock)
             {
-                EnsureCurrentDate();
                 return GenerateDailyThreadId(_currentCycleDate);
             }
-        }
-    }
-
-    /// <summary>
-    /// Advances cycle date if it's a new day. Does NOT run learning (that requires async).
-    /// Call StartNewCycleAsync for full cycle rotation with learning.
-    /// </summary>
-    private void EnsureCurrentDate()
-    {
-        var today = DateTime.UtcNow.ToString("yyyy-MM-dd");
-        if (today != _currentCycleDate)
-        {
-            _currentCycleDate = today;
-            _hasConversation = false;
         }
     }
 

--- a/src/HomelabBot/Services/SmartNotificationService.cs
+++ b/src/HomelabBot/Services/SmartNotificationService.cs
@@ -106,7 +106,9 @@ public sealed class SmartNotificationService
 
         var preferences = await LoadNotificationPreferencesAsync();
 
-        if (candidate.IssueType != null && IsIssueSuppressed(candidate.IssueType, preferences))
+        if (!candidate.NeverSuppress
+            && candidate.IssueType != null
+            && IsIssueSuppressed(candidate.IssueType, preferences))
         {
             _logger.LogInformation("Issue type '{IssueType}' is suppressed, skipping", candidate.IssueType);
             return false;

--- a/src/HomelabBot/Services/SmartNotificationService.cs
+++ b/src/HomelabBot/Services/SmartNotificationService.cs
@@ -51,8 +51,23 @@ public sealed class SmartNotificationService
         {
             lock (_cycleLock)
             {
+                EnsureCurrentDate();
                 return GenerateDailyThreadId(_currentCycleDate);
             }
+        }
+    }
+
+    /// <summary>
+    /// Advances cycle date if it's a new day. Does NOT run learning (that requires async).
+    /// Call StartNewCycleAsync for full cycle rotation with learning.
+    /// </summary>
+    private void EnsureCurrentDate()
+    {
+        var today = DateTime.UtcNow.ToString("yyyy-MM-dd");
+        if (today != _currentCycleDate)
+        {
+            _currentCycleDate = today;
+            _hasConversation = false;
         }
     }
 
@@ -134,7 +149,10 @@ public sealed class SmartNotificationService
             return false;
         }
 
-        var shouldNotify = analysis.Contains(NotificationPrompts.TagNotify, StringComparison.OrdinalIgnoreCase);
+        // Parse the last non-empty line for the decision tag to avoid false positives
+        var lastLine = analysis.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .LastOrDefault() ?? "";
+        var shouldNotify = lastLine.Equals(NotificationPrompts.TagNotify, StringComparison.OrdinalIgnoreCase);
 
         if (!shouldNotify)
         {
@@ -273,10 +291,9 @@ public sealed class SmartNotificationService
 
     private static bool IsIssueSuppressed(string issueType, List<Knowledge> preferences)
     {
-        var normalizedType = NormalizeIssueType(issueType);
+        var expectedTopic = $"{TopicPrefixSuppress}{NormalizeIssueType(issueType)}";
         return preferences.Any(p =>
-            p.Topic.StartsWith(TopicPrefixSuppress, StringComparison.OrdinalIgnoreCase) &&
-            p.Topic.Contains(normalizedType, StringComparison.OrdinalIgnoreCase) &&
+            p.Topic.Equals(expectedTopic, StringComparison.OrdinalIgnoreCase) &&
             p.Confidence >= 0.5);
     }
 

--- a/src/HomelabBot/Services/SmartNotificationService.cs
+++ b/src/HomelabBot/Services/SmartNotificationService.cs
@@ -1,0 +1,314 @@
+using System.Security.Cryptography;
+using System.Text;
+using HomelabBot.Configuration;
+using HomelabBot.Data.Entities;
+using HomelabBot.Models;
+
+namespace HomelabBot.Services;
+
+public sealed class SmartNotificationService
+{
+    private const string TopicPrefixSuppress = "notification_preference:suppress:";
+    private const string TopicPrefixAlways = "notification_preference:always:";
+    private const string TopicPrefix = "notification_preference";
+    internal const string ButtonPrefixNormal = "notif_normal_";
+    internal const string ButtonPrefixInvestigate = "notif_investigate_";
+
+    private readonly KernelService _kernelService;
+    private readonly ConversationService _conversationService;
+    private readonly DiscordBotService _discordBot;
+    private readonly KnowledgeService _knowledgeService;
+    private readonly ILogger<SmartNotificationService> _logger;
+    private readonly Lock _cycleLock = new();
+
+    private string _currentCycleDate = "";
+    private bool _hasConversation;
+
+    public SmartNotificationService(
+        KernelService kernelService,
+        ConversationService conversationService,
+        DiscordBotService discordBot,
+        KnowledgeService knowledgeService,
+        ILogger<SmartNotificationService> logger)
+    {
+        _kernelService = kernelService;
+        _conversationService = conversationService;
+        _discordBot = discordBot;
+        _knowledgeService = knowledgeService;
+        _logger = logger;
+
+        lock (_cycleLock)
+        {
+            // Use yesterday so the first StartNewCycleAsync call always rotates to today,
+            // ensuring cleanup of any orphaned conversation from a previous process.
+            _currentCycleDate = DateTime.UtcNow.AddDays(-1).ToString("yyyy-MM-dd");
+        }
+    }
+
+    public ulong CurrentDailyThreadId
+    {
+        get
+        {
+            lock (_cycleLock)
+            {
+                return GenerateDailyThreadId(_currentCycleDate);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Start a new daily cycle. Runs end-of-cycle learning on the previous conversation,
+    /// then resets context for the new day.
+    /// </summary>
+    public async Task StartNewCycleAsync(CancellationToken ct)
+    {
+        string previousDate;
+        bool hadConversation;
+        ulong previousThreadId;
+
+        lock (_cycleLock)
+        {
+            var today = DateTime.UtcNow.ToString("yyyy-MM-dd");
+            if (today == _currentCycleDate)
+            {
+                return;
+            }
+
+            previousDate = _currentCycleDate;
+            hadConversation = _hasConversation;
+            previousThreadId = GenerateDailyThreadId(_currentCycleDate);
+
+            _currentCycleDate = today;
+            _hasConversation = false;
+        }
+
+        if (hadConversation && previousThreadId != 0)
+        {
+            await RunEndOfCycleLearningAsync(previousThreadId, previousDate, ct);
+        }
+
+        if (previousThreadId != 0)
+        {
+            _conversationService.ClearHistory(previousThreadId);
+        }
+
+        _logger.LogInformation("Started new notification cycle {Date}", _currentCycleDate);
+    }
+
+    /// <summary>
+    /// Evaluate a finding: investigate via LLM, decide if it's worth notifying the owner.
+    /// Returns true if a notification was actually sent.
+    /// </summary>
+    public async Task<bool> EvaluateAndNotifyAsync(NotificationCandidate candidate, CancellationToken ct)
+    {
+        _logger.LogInformation("Evaluating notification candidate from {Source}: {Summary}",
+            candidate.Source, candidate.Summary);
+
+        var preferences = await LoadNotificationPreferencesAsync();
+
+        if (candidate.IssueType != null && IsIssueSuppressed(candidate.IssueType, preferences))
+        {
+            _logger.LogInformation("Issue type '{IssueType}' is suppressed, skipping", candidate.IssueType);
+            return false;
+        }
+
+        var prefsText = FormatPreferences(preferences);
+        var prompt = candidate.AlreadyInvestigated
+            ? NotificationPrompts.BuildDecisionOnlyPrompt(candidate.Summary, candidate.RawData, prefsText)
+            : NotificationPrompts.BuildInvestigationPrompt(candidate.Summary, candidate.RawData, prefsText);
+
+        string analysis;
+        try
+        {
+            analysis = await _kernelService.ProcessMessageAsync(
+                threadId: CurrentDailyThreadId,
+                userMessage: prompt,
+                traceType: TraceType.Scheduled,
+                maxTokens: NotificationPrompts.MaxTokens,
+                systemPromptOverride: NotificationPrompts.InvestigationSystem,
+                ct: ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to run LLM investigation for {Source}", candidate.Source);
+            return false;
+        }
+
+        var shouldNotify = analysis.Contains(NotificationPrompts.TagNotify, StringComparison.OrdinalIgnoreCase);
+
+        if (!shouldNotify)
+        {
+            _logger.LogInformation("LLM decided not to notify for {Source}: {Summary}",
+                candidate.Source, candidate.Summary);
+            return false;
+        }
+
+        var report = candidate.AlreadyInvestigated
+            ? candidate.RawData
+            : analysis
+                .Replace(NotificationPrompts.TagNotify, "", StringComparison.OrdinalIgnoreCase)
+                .Replace(NotificationPrompts.TagSilent, "", StringComparison.OrdinalIgnoreCase)
+                .Trim();
+
+        return await SendNotificationAsync(report, candidate);
+    }
+
+    /// <summary>
+    /// Handle "Normal, ignore in future" button press.
+    /// </summary>
+    public async Task HandleSuppressFeedbackAsync(string issueType, string description)
+    {
+        await _knowledgeService.RememberFactAsync(
+            topic: $"{TopicPrefixSuppress}{issueType}",
+            fact: $"Owner marked as normal/ignorable: {description}",
+            source: "user_feedback",
+            confidence: 1.0);
+
+        _logger.LogInformation("Stored suppression preference for issue type '{IssueType}'", issueType);
+    }
+
+    /// <summary>
+    /// Record that the owner replied in DMs (for end-of-cycle learning).
+    /// </summary>
+    public void MarkConversationActive()
+    {
+        lock (_cycleLock)
+        {
+            _hasConversation = true;
+        }
+    }
+
+    private async Task<bool> SendNotificationAsync(string report, NotificationCandidate candidate)
+    {
+        var userId = HomelabOwner.DiscordUserId;
+        if (userId == 0)
+        {
+            return false;
+        }
+
+        var issueType = NormalizeIssueType(candidate.IssueType ?? candidate.Source);
+
+        try
+        {
+            await _discordBot.SendDmSplitAsync(userId, report);
+            await _discordBot.SendDmNotificationFeedbackAsync(userId, issueType);
+
+            _logger.LogInformation("Sent smart notification for {Source}", candidate.Source);
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to send notification for {Source}", candidate.Source);
+            return false;
+        }
+    }
+
+    private async Task RunEndOfCycleLearningAsync(ulong threadId, string cycleDate, CancellationToken ct)
+    {
+        _logger.LogInformation("Running end-of-cycle learning for {Date}", cycleDate);
+
+        try
+        {
+            var learningThreadId = (ulong)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+            var analysis = await _kernelService.ProcessMessageAsync(
+                threadId: learningThreadId,
+                userMessage: NotificationPrompts.EndOfCycleLearning,
+                traceType: TraceType.Scheduled,
+                maxTokens: 1024,
+                ct: ct);
+
+            _conversationService.ClearHistory(learningThreadId);
+
+            if (analysis.Contains(NotificationPrompts.TagNoUpdates, StringComparison.OrdinalIgnoreCase))
+            {
+                _logger.LogInformation("No notification preference updates from cycle conversation");
+                return;
+            }
+
+            foreach (var line in analysis.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
+            {
+                await TryStoreLearningPreferenceAsync(line, "SUPPRESS:", "suppress",
+                    "Owner considers this non-actionable", 0.8);
+                await TryStoreLearningPreferenceAsync(line, "ALWAYS:", "always",
+                    "Owner wants to always be notified", 0.9);
+            }
+
+            _logger.LogInformation("End-of-cycle learning completed for {Date}", cycleDate);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to run end-of-cycle learning");
+        }
+    }
+
+    private async Task TryStoreLearningPreferenceAsync(
+        string line, string prefix, string topicSegment, string factTemplate, double confidence)
+    {
+        if (!line.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+        {
+            return;
+        }
+
+        var content = line[prefix.Length..].Trim();
+        var parts = content.Split('—', 2);
+        var issueType = NormalizeIssueType(parts[0].Trim());
+        var reason = parts.Length > 1 ? parts[1].Trim() : "Inferred from conversation";
+
+        await _knowledgeService.RememberFactAsync(
+            topic: $"notification_preference:{topicSegment}:{issueType}",
+            fact: $"{factTemplate}: {reason}",
+            source: "cycle_analysis",
+            confidence: confidence);
+    }
+
+    private async Task<List<Knowledge>> LoadNotificationPreferencesAsync()
+    {
+        try
+        {
+            return await _knowledgeService.RecallAsync(TopicPrefix);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to load notification preferences");
+            return [];
+        }
+    }
+
+    private static bool IsIssueSuppressed(string issueType, List<Knowledge> preferences)
+    {
+        var normalizedType = NormalizeIssueType(issueType);
+        return preferences.Any(p =>
+            p.Topic.StartsWith(TopicPrefixSuppress, StringComparison.OrdinalIgnoreCase) &&
+            p.Topic.Contains(normalizedType, StringComparison.OrdinalIgnoreCase) &&
+            p.Confidence >= 0.5);
+    }
+
+    private static string FormatPreferences(List<Knowledge> preferences)
+    {
+        if (preferences.Count == 0)
+        {
+            return "";
+        }
+
+        var sb = new StringBuilder();
+        foreach (var pref in preferences)
+        {
+            var type = pref.Topic.StartsWith(TopicPrefixSuppress)
+                ? "SUPPRESS" : pref.Topic.StartsWith(TopicPrefixAlways)
+                    ? "ALWAYS" : "PREF";
+            var key = pref.Topic.Split(':').LastOrDefault() ?? pref.Topic;
+            sb.AppendLine($"- {type} {key}: {pref.Fact}");
+        }
+
+        return sb.ToString();
+    }
+
+    private static string NormalizeIssueType(string issueType) =>
+        issueType.ToLowerInvariant().Replace(' ', '_');
+
+    private static ulong GenerateDailyThreadId(string dateString)
+    {
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes($"daily_notification_{dateString}"));
+        return BitConverter.ToUInt64(hash, 0);
+    }
+}

--- a/src/HomelabBot/Services/SmartNotificationService.cs
+++ b/src/HomelabBot/Services/SmartNotificationService.cs
@@ -196,16 +196,24 @@ public sealed class SmartNotificationService
         try
         {
             await _discordBot.SendDmSplitAsync(userId, report);
-            await _discordBot.SendDmNotificationFeedbackAsync(userId, issueType);
-
-            _logger.LogInformation("Sent smart notification for {Source}", candidate.Source);
-            return true;
         }
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Failed to send notification for {Source}", candidate.Source);
             return false;
         }
+
+        try
+        {
+            await _discordBot.SendDmNotificationFeedbackAsync(userId, issueType);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to send feedback buttons for {Source}", candidate.Source);
+        }
+
+        _logger.LogInformation("Sent smart notification for {Source}", candidate.Source);
+        return true;
     }
 
     private async Task RunEndOfCycleLearningAsync(ulong threadId, string cycleDate, CancellationToken ct)

--- a/tests/HomelabBot.Tests/LogAnomalyServiceTests.cs
+++ b/tests/HomelabBot.Tests/LogAnomalyServiceTests.cs
@@ -21,8 +21,7 @@ public class LogAnomalyServiceTests
         _service = new LogAnomalyService(
             configMonitor,
             null!,  // LokiPlugin
-            null!,  // KernelService
-            null!,  // ConversationService
+            null!,  // SmartNotificationService
             null!,  // DiscordBotService
             NullLogger<LogAnomalyService>.Instance,
             null!); // ServiceStateStore


### PR DESCRIPTION
## Summary
- Replace direct DM sends across all 4 notification sources (daily healthcheck, anomaly detection, log anomaly, health score) with unified `SmartNotificationService` that investigates findings via LLM before deciding whether to notify
- Enable DM receiving — bot can now respond to owner's messages in DMs with full tool access, sharing daily conversation context
- Add notification feedback buttons ("Normal, ignore in future" / "Investigate further") that store preferences via Knowledge system
- End-of-cycle learning extracts notification preferences from DM conversations before context reset at next daily run
- Daily healthcheck no longer always sends a report — only notifies when something actionable is found

## New files
- `Models/NotificationCandidate.cs` — model for notification candidates
- `Services/SmartNotificationService.cs` — unified investigate-then-notify pipeline with cycle management
- `Services/NotificationPrompts.cs` — LLM prompts for investigation, decision, and learning

## Modified files
- `DiscordBotService.cs` — DirectMessages intent, DM handler, notification feedback buttons
- `DailySummaryService.cs` — routes through SmartNotificationService, no longer clears context immediately
- `AnomalyDetectionService.cs` — routes through SmartNotificationService instead of direct DM
- `LogAnomalyService.cs` — batches findings into single candidate, routes through SmartNotificationService
- `HealthScoreBackgroundService.cs` — routes through SmartNotificationService, only updates notification gate when actually sent
- `Program.cs` — registers SmartNotificationService

## Test plan
- [ ] Daily run with nothing wrong: bot runs healthcheck, LLM says SILENT, no DM sent
- [ ] Daily run with real issue: bot sends DM with analysis + buttons, reply in DMs works
- [ ] Log anomaly not significant: LLM investigates, determines harmless, no DM
- [ ] Health score drop: LLM investigates what caused deductions before deciding
- [ ] Button feedback: click "Normal, ignore in future" → verify Knowledge entry created
- [ ] Context continuity: multiple notifications in same day share conversation context
- [ ] Context reset: next daily run clears previous day's context

🤖 Generated with [Claude Code](https://claude.com/claude-code)