### PR TITLE
Extract shared Prometheus client, keyword matcher, and structured plugin data

### DIFF
--- a/src/HomelabBot/Controllers/InvestigationsController.cs
+++ b/src/HomelabBot/Controllers/InvestigationsController.cs
@@ -161,13 +161,13 @@ public class InvestigationsController : ControllerBase
         [FromQuery] int limit = 5)
     {
         var items = await _similarityService.FindSimilarAsync(symptom, limit: limit);
-        var ids = items.Select(i => i.InvestigationId).ToList();
+        if (items.Count == 0)
+        {
+            return Ok(new List<InvestigationDto>());
+        }
 
-        // Look up full investigations to populate all DTO fields
-        var (allInvestigations, _) = await _memoryService.GetInvestigationsAsync(pageSize: 100, resolved: true);
-        var lookup = allInvestigations
-            .Where(inv => ids.Contains(inv.Id))
-            .ToDictionary(inv => inv.Id);
+        var ids = items.Select(i => i.InvestigationId).ToList();
+        var lookup = await _memoryService.GetInvestigationsByIdsAsync(ids);
 
         return Ok(items.Select(i =>
         {

--- a/src/HomelabBot/Controllers/InvestigationsController.cs
+++ b/src/HomelabBot/Controllers/InvestigationsController.cs
@@ -8,10 +8,12 @@ namespace HomelabBot.Controllers;
 public class InvestigationsController : ControllerBase
 {
     private readonly MemoryService _memoryService;
+    private readonly IncidentSimilarityService _similarityService;
 
-    public InvestigationsController(MemoryService memoryService)
+    public InvestigationsController(MemoryService memoryService, IncidentSimilarityService similarityService)
     {
         _memoryService = memoryService;
+        _similarityService = similarityService;
     }
 
     [HttpGet]
@@ -158,17 +160,28 @@ public class InvestigationsController : ControllerBase
         [FromQuery] string symptom,
         [FromQuery] int limit = 5)
     {
-        var items = await _memoryService.SearchPastIncidentsAsync(symptom, limit);
+        var items = await _similarityService.FindSimilarAsync(symptom, limit: limit);
+        var ids = items.Select(i => i.InvestigationId).ToList();
 
-        return Ok(items.Select(i => new InvestigationDto
+        // Look up full investigations to populate all DTO fields
+        var (allInvestigations, _) = await _memoryService.GetInvestigationsAsync(pageSize: 100, resolved: true);
+        var lookup = allInvestigations
+            .Where(inv => ids.Contains(inv.Id))
+            .ToDictionary(inv => inv.Id);
+
+        return Ok(items.Select(i =>
         {
-            Id = i.Id,
-            ThreadId = i.ThreadId.ToString(),
-            Trigger = i.Trigger,
-            StartedAt = i.StartedAt,
-            Resolved = i.Resolved,
-            Resolution = i.Resolution,
-            StepCount = i.Steps.Count
+            lookup.TryGetValue(i.InvestigationId, out var inv);
+            return new InvestigationDto
+            {
+                Id = i.InvestigationId,
+                ThreadId = inv?.ThreadId.ToString() ?? "",
+                Trigger = i.Trigger ?? "",
+                StartedAt = i.OccurredAt,
+                Resolved = inv?.Resolved ?? true,
+                Resolution = i.Resolution,
+                StepCount = inv?.Steps.Count ?? 0
+            };
         }).ToList());
     }
 }

--- a/src/HomelabBot/Models/PoolInfo.cs
+++ b/src/HomelabBot/Models/PoolInfo.cs
@@ -1,0 +1,14 @@
+namespace HomelabBot.Models;
+
+public sealed class PoolInfo
+{
+    public required string Name { get; init; }
+
+    public required string Status { get; init; }
+
+    public bool Healthy { get; init; }
+
+    public long AllocatedBytes { get; init; }
+
+    public long SizeBytes { get; init; }
+}

--- a/src/HomelabBot/Models/Prometheus/MetricResult.cs
+++ b/src/HomelabBot/Models/Prometheus/MetricResult.cs
@@ -1,0 +1,8 @@
+namespace HomelabBot.Models.Prometheus;
+
+public sealed class MetricResult
+{
+    public Dictionary<string, string> Labels { get; set; } = [];
+
+    public double Value { get; set; }
+}

--- a/src/HomelabBot/Models/Prometheus/PrometheusLabelResponse.cs
+++ b/src/HomelabBot/Models/Prometheus/PrometheusLabelResponse.cs
@@ -1,0 +1,8 @@
+namespace HomelabBot.Models.Prometheus;
+
+public sealed class PrometheusLabelResponse
+{
+    public string Status { get; set; } = "";
+
+    public List<string> Data { get; set; } = [];
+}

--- a/src/HomelabBot/Models/Prometheus/PrometheusQueryRangeResponse.cs
+++ b/src/HomelabBot/Models/Prometheus/PrometheusQueryRangeResponse.cs
@@ -1,0 +1,20 @@
+using System.Text.Json;
+
+namespace HomelabBot.Models.Prometheus;
+
+public sealed class PrometheusQueryRangeResponse
+{
+    public PrometheusQueryRangeData? Data { get; set; }
+}
+
+public sealed class PrometheusQueryRangeData
+{
+    public List<PrometheusRangeResult>? Result { get; set; }
+}
+
+public sealed class PrometheusRangeResult
+{
+    public Dictionary<string, string>? Metric { get; set; }
+
+    public JsonElement[][]? Values { get; set; }
+}

--- a/src/HomelabBot/Models/Prometheus/PrometheusQueryResponse.cs
+++ b/src/HomelabBot/Models/Prometheus/PrometheusQueryResponse.cs
@@ -1,0 +1,24 @@
+using System.Text.Json;
+
+namespace HomelabBot.Models.Prometheus;
+
+public sealed class PrometheusQueryResponse
+{
+    public string Status { get; set; } = "";
+
+    public PrometheusQueryData? Data { get; set; }
+}
+
+public sealed class PrometheusQueryData
+{
+    public string ResultType { get; set; } = "";
+
+    public List<PrometheusResult> Result { get; set; } = [];
+}
+
+public sealed class PrometheusResult
+{
+    public Dictionary<string, string>? Metric { get; set; }
+
+    public JsonElement[]? Value { get; set; }
+}

--- a/src/HomelabBot/Models/Prometheus/PrometheusTargetInfo.cs
+++ b/src/HomelabBot/Models/Prometheus/PrometheusTargetInfo.cs
@@ -1,0 +1,10 @@
+namespace HomelabBot.Models.Prometheus;
+
+public sealed class PrometheusTargetInfo
+{
+    public required string Job { get; init; }
+
+    public required string Instance { get; init; }
+
+    public required string Health { get; init; }
+}

--- a/src/HomelabBot/Models/Prometheus/PrometheusTargetsResponse.cs
+++ b/src/HomelabBot/Models/Prometheus/PrometheusTargetsResponse.cs
@@ -1,0 +1,22 @@
+namespace HomelabBot.Models.Prometheus;
+
+public sealed class PrometheusTargetsResponse
+{
+    public string Status { get; set; } = "";
+
+    public PrometheusTargetsData? Data { get; set; }
+}
+
+public sealed class PrometheusTargetsData
+{
+    public List<PrometheusTarget> ActiveTargets { get; set; } = [];
+}
+
+public sealed class PrometheusTarget
+{
+    public Dictionary<string, string>? Labels { get; set; }
+
+    public string? ScrapeUrl { get; set; }
+
+    public string Health { get; set; } = "";
+}

--- a/src/HomelabBot/Plugins/InvestigationPlugin.cs
+++ b/src/HomelabBot/Plugins/InvestigationPlugin.cs
@@ -181,7 +181,7 @@ public sealed class InvestigationPlugin
     {
         _logger.LogDebug("Searching past incidents for '{Symptom}'", symptom);
 
-        var incidents = await _memoryService.SearchPastIncidentsAsync(symptom);
+        var incidents = await _similarityService.FindSimilarAsync(symptom);
 
         if (incidents.Count == 0)
         {
@@ -193,19 +193,19 @@ public sealed class InvestigationPlugin
 
         foreach (var incident in incidents)
         {
-            var age = DateTime.UtcNow - incident.StartedAt;
+            var age = DateTime.UtcNow - incident.OccurredAt;
             var timeAgo = age.TotalDays > 1 ? $"{(int)age.TotalDays} days ago" : $"{(int)age.TotalHours} hours ago";
 
-            sb.AppendLine($"**#{incident.Id}** ({timeAgo})");
+            sb.AppendLine($"**#{incident.InvestigationId}** ({timeAgo}, {incident.SimilarityScore:F0}% match)");
             sb.AppendLine($"  Problem: {incident.Trigger}");
             if (!string.IsNullOrEmpty(incident.Resolution))
             {
                 sb.AppendLine($"  Resolution: {incident.Resolution}");
             }
 
-            if (incident.Steps.Count > 0)
+            if (incident.MatchReasons.Count > 0)
             {
-                sb.AppendLine($"  Steps: {incident.Steps.Count}");
+                sb.AppendLine($"  Match: {string.Join(", ", incident.MatchReasons)}");
             }
 
             sb.AppendLine();

--- a/src/HomelabBot/Plugins/MikroTikPlugin.cs
+++ b/src/HomelabBot/Plugins/MikroTikPlugin.cs
@@ -1,8 +1,8 @@
 using System.ComponentModel;
-using System.Net.Http.Json;
 using System.Text;
-using System.Text.Json;
 using HomelabBot.Configuration;
+using HomelabBot.Models.Prometheus;
+using HomelabBot.Services;
 using Microsoft.Extensions.Options;
 using Microsoft.SemanticKernel;
 
@@ -10,21 +10,18 @@ namespace HomelabBot.Plugins;
 
 public sealed class MikroTikPlugin
 {
-    private readonly HttpClient _httpClient;
+    private readonly PrometheusQueryService _prometheus;
     private readonly ILogger<MikroTikPlugin> _logger;
-    private readonly string _prometheusUrl;
     private readonly MikroTikConfiguration _config;
 
     public MikroTikPlugin(
-        IHttpClientFactory httpClientFactory,
+        PrometheusQueryService prometheus,
         IOptions<MikroTikConfiguration> config,
-        IOptions<PrometheusConfiguration> prometheusConfig,
         ILogger<MikroTikPlugin> logger)
     {
-        _httpClient = httpClientFactory.CreateClient("Default");
+        _prometheus = prometheus;
         _logger = logger;
         _config = config.Value;
-        _prometheusUrl = prometheusConfig.Value.Host.TrimEnd('/');
     }
 
     [KernelFunction]
@@ -36,37 +33,28 @@ public sealed class MikroTikPlugin
         var sb = new StringBuilder();
         sb.AppendLine("**MikroTik Router Status**\n");
 
-        // Uptime
-        var uptimeSeconds = await QueryPrometheusValue("mktxp_system_uptime");
-        if (uptimeSeconds > 0)
+        var metrics = await GetRouterMetricsAsync();
+
+        if (metrics.Uptime > TimeSpan.Zero)
         {
-            var uptime = TimeSpan.FromSeconds(uptimeSeconds);
-            sb.AppendLine($"Uptime: **{uptime.Days}d {uptime.Hours}h {uptime.Minutes}m**");
+            sb.AppendLine($"Uptime: **{metrics.Uptime.Days}d {metrics.Uptime.Hours}h {metrics.Uptime.Minutes}m**");
         }
 
-        // CPU
-        var cpuLoad = await QueryPrometheusValue("mktxp_system_cpu_load");
-        sb.AppendLine($"CPU Load: **{cpuLoad:F0}%**");
+        sb.AppendLine($"CPU Load: **{metrics.CpuLoad:F0}%**");
 
-        // Memory
-        var memTotal = await QueryPrometheusValue("mktxp_system_total_memory");
-        var memFree = await QueryPrometheusValue("mktxp_system_free_memory");
-        if (memTotal > 0)
+        if (metrics.MemoryTotal > 0)
         {
-            var memUsedPercent = ((memTotal - memFree) / memTotal) * 100;
-            sb.AppendLine($"Memory: **{memUsedPercent:F1}%** used ({FormatBytes(memTotal - memFree)} / {FormatBytes(memTotal)})");
+            var memUsed = metrics.MemoryTotal - metrics.MemoryFree;
+            sb.AppendLine($"Memory: **{metrics.MemoryPercent:F1}%** used ({FormatBytes(memUsed)} / {FormatBytes(metrics.MemoryTotal)})");
         }
 
-        // Temperature
-        var temp = await QueryPrometheusValue("mktxp_system_cpu_temperature");
-        if (temp > 0)
+        if (metrics.Temperature > 0)
         {
-            sb.AppendLine($"CPU Temperature: **{temp:F1}°C**");
+            sb.AppendLine($"CPU Temperature: **{metrics.Temperature:F1}°C**");
         }
 
-        // Free disk space
-        var diskFree = await QueryPrometheusValue("mktxp_system_free_hdd_space");
-        var diskTotal = await QueryPrometheusValue("mktxp_system_total_hdd_space");
+        var diskFree = await _prometheus.QueryScalarAsync("mktxp_system_free_hdd_space") ?? 0;
+        var diskTotal = await _prometheus.QueryScalarAsync("mktxp_system_total_hdd_space") ?? 0;
         if (diskTotal > 0)
         {
             var diskUsedPercent = ((diskTotal - diskFree) / diskTotal) * 100;
@@ -84,12 +72,8 @@ public sealed class MikroTikPlugin
 
         try
         {
-            // Query all interface metrics
-            var txQuery = "rate(mktxp_interface_tx_byte[5m])";
-            var rxQuery = "rate(mktxp_interface_rx_byte[5m])";
-
-            var txResults = await QueryPrometheusMultiple(txQuery);
-            var rxResults = await QueryPrometheusMultiple(rxQuery);
+            var txResults = await _prometheus.QueryMultipleAsync("rate(mktxp_interface_tx_byte[5m])");
+            var rxResults = await _prometheus.QueryMultipleAsync("rate(mktxp_interface_rx_byte[5m])");
 
             if (txResults.Count == 0)
             {
@@ -143,8 +127,7 @@ public sealed class MikroTikPlugin
 
         try
         {
-            var signalQuery = "mktxp_wifi_client_signal";
-            var results = await QueryPrometheusMultiple(signalQuery);
+            var results = await _prometheus.QueryMultipleAsync("mktxp_wifi_client_signal");
 
             if (results.Count == 0)
             {
@@ -180,9 +163,7 @@ public sealed class MikroTikPlugin
 
         try
         {
-            // MKTXP exports DHCP lease info
-            var leaseQuery = "mktxp_dhcp_lease_info";
-            var results = await QueryPrometheusMultiple(leaseQuery);
+            var results = await _prometheus.QueryMultipleAsync("mktxp_dhcp_lease_info");
 
             if (results.Count == 0)
             {
@@ -261,66 +242,25 @@ public sealed class MikroTikPlugin
         }
     }
 
-    private async Task<double> QueryPrometheusValue(string metric)
+    internal async Task<RouterMetrics> GetRouterMetricsAsync(CancellationToken ct = default)
     {
-        try
+        var cpuLoad = await _prometheus.QueryScalarAsync("mktxp_system_cpu_load", ct) ?? 0;
+        var memTotal = await _prometheus.QueryScalarAsync("mktxp_system_total_memory", ct) ?? 0;
+        var memFree = await _prometheus.QueryScalarAsync("mktxp_system_free_memory", ct) ?? 0;
+        var temp = await _prometheus.QueryScalarAsync("mktxp_system_cpu_temperature", ct) ?? 0;
+        var uptimeSeconds = await _prometheus.QueryScalarAsync("mktxp_system_uptime", ct) ?? 0;
+
+        var memPercent = memTotal > 0 ? ((memTotal - memFree) / memTotal) * 100 : 0;
+
+        return new RouterMetrics
         {
-            var encodedQuery = Uri.EscapeDataString(metric);
-            var response = await _httpClient.GetAsync($"{_prometheusUrl}/api/v1/query?query={encodedQuery}");
-            response.EnsureSuccessStatusCode();
-
-            var result = await response.Content.ReadFromJsonAsync<PrometheusResponse>();
-            if (result?.Data?.Result?.FirstOrDefault()?.Value?.Length > 1)
-            {
-                if (double.TryParse(result.Data.Result[0].Value![1].ToString(), out var value))
-                {
-                    return value;
-                }
-            }
-
-            return 0;
-        }
-        catch
-        {
-            return 0;
-        }
-    }
-
-    private async Task<List<MetricResult>> QueryPrometheusMultiple(string query)
-    {
-        var results = new List<MetricResult>();
-
-        try
-        {
-            var encodedQuery = Uri.EscapeDataString(query);
-            var response = await _httpClient.GetAsync($"{_prometheusUrl}/api/v1/query?query={encodedQuery}");
-            response.EnsureSuccessStatusCode();
-
-            var result = await response.Content.ReadFromJsonAsync<PrometheusResponse>();
-            if (result?.Data?.Result != null)
-            {
-                foreach (var item in result.Data.Result)
-                {
-                    var value = 0.0;
-                    if (item.Value?.Length > 1)
-                    {
-                        double.TryParse(item.Value[1].ToString(), out value);
-                    }
-
-                    results.Add(new MetricResult
-                    {
-                        Labels = item.Metric ?? [],
-                        Value = value
-                    });
-                }
-            }
-        }
-        catch
-        {
-            // Return empty list on error
-        }
-
-        return results;
+            CpuLoad = cpuLoad,
+            MemoryPercent = memPercent,
+            MemoryTotal = memTotal,
+            MemoryFree = memFree,
+            Temperature = temp,
+            Uptime = TimeSpan.FromSeconds(uptimeSeconds)
+        };
     }
 
     private static string FormatBytes(double bytes)
@@ -374,32 +314,19 @@ public sealed class MikroTikPlugin
             _ => "📶░░░░"
         };
     }
+}
 
-    private sealed class MetricResult
-    {
-        public Dictionary<string, string> Labels { get; set; } = [];
+public sealed class RouterMetrics
+{
+    public double CpuLoad { get; init; }
 
-        public double Value { get; set; }
-    }
+    public double MemoryPercent { get; init; }
 
-    private sealed class PrometheusResponse
-    {
-        public string Status { get; set; } = "";
+    public double MemoryTotal { get; init; }
 
-        public PrometheusData? Data { get; set; }
-    }
+    public double MemoryFree { get; init; }
 
-    private sealed class PrometheusData
-    {
-        public string ResultType { get; set; } = "";
+    public double Temperature { get; init; }
 
-        public List<PrometheusResult>? Result { get; set; }
-    }
-
-    private sealed class PrometheusResult
-    {
-        public Dictionary<string, string>? Metric { get; set; }
-
-        public JsonElement[]? Value { get; set; }
-    }
+    public TimeSpan Uptime { get; init; }
 }

--- a/src/HomelabBot/Plugins/PrometheusPlugin.cs
+++ b/src/HomelabBot/Plugins/PrometheusPlugin.cs
@@ -1,27 +1,22 @@
 using System.ComponentModel;
-using System.Net.Http.Json;
 using System.Text;
-using System.Text.Json;
-using HomelabBot.Configuration;
-using Microsoft.Extensions.Options;
+using HomelabBot.Models.Prometheus;
+using HomelabBot.Services;
 using Microsoft.SemanticKernel;
 
 namespace HomelabBot.Plugins;
 
 public sealed class PrometheusPlugin
 {
-    private readonly HttpClient _httpClient;
+    private readonly PrometheusQueryService _prometheus;
     private readonly ILogger<PrometheusPlugin> _logger;
-    private readonly string _baseUrl;
 
     public PrometheusPlugin(
-        IHttpClientFactory httpClientFactory,
-        IOptions<PrometheusConfiguration> config,
+        PrometheusQueryService prometheus,
         ILogger<PrometheusPlugin> logger)
     {
-        _httpClient = httpClientFactory.CreateClient("Default");
+        _prometheus = prometheus;
         _logger = logger;
-        _baseUrl = config.Value.Host.TrimEnd('/');
     }
 
     [KernelFunction]
@@ -32,10 +27,7 @@ public sealed class PrometheusPlugin
 
         try
         {
-            var response = await _httpClient.GetAsync($"{_baseUrl}/api/v1/label/__name__/values");
-            response.EnsureSuccessStatusCode();
-
-            var result = await response.Content.ReadFromJsonAsync<PrometheusLabelResponse>();
+            var result = await _prometheus.GetLabelValuesAsync("__name__");
 
             if (result?.Data == null || result.Data.Count == 0)
             {
@@ -97,11 +89,7 @@ public sealed class PrometheusPlugin
 
         try
         {
-            var encodedQuery = Uri.EscapeDataString(query);
-            var response = await _httpClient.GetAsync($"{_baseUrl}/api/v1/query?query={encodedQuery}");
-            response.EnsureSuccessStatusCode();
-
-            var result = await response.Content.ReadFromJsonAsync<PrometheusQueryResponse>();
+            var result = await _prometheus.QueryAsync(query);
 
             if (result?.Data?.Result == null || result.Data.Result.Count == 0)
             {
@@ -143,29 +131,27 @@ public sealed class PrometheusPlugin
         sb.AppendLine("**Node Statistics**\n");
 
         // CPU usage
-        var cpuQuery = "100 - (avg(rate(node_cpu_seconds_total{mode=\"idle\"}[5m])) * 100)";
-        var cpuResult = await QuerySingleValue(cpuQuery);
-        sb.AppendLine($"CPU Usage: **{cpuResult:F1}%**");
+        var cpuResult = await _prometheus.QueryScalarAsync(
+            "100 - (avg(rate(node_cpu_seconds_total{mode=\"idle\"}[5m])) * 100)");
+        sb.AppendLine($"CPU Usage: **{cpuResult ?? 0:F1}%**");
 
         // Memory usage
-        var memQuery = "(1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)) * 100";
-        var memResult = await QuerySingleValue(memQuery);
-        sb.AppendLine($"Memory Usage: **{memResult:F1}%**");
+        var memResult = await _prometheus.QueryScalarAsync(
+            "(1 - (node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)) * 100");
+        sb.AppendLine($"Memory Usage: **{memResult ?? 0:F1}%**");
 
         // Disk usage (root filesystem)
-        var diskQuery = "(1 - (node_filesystem_avail_bytes{mountpoint=\"/\"} / node_filesystem_size_bytes{mountpoint=\"/\"})) * 100";
-        var diskResult = await QuerySingleValue(diskQuery);
-        sb.AppendLine($"Disk Usage (/): **{diskResult:F1}%**");
+        var diskResult = await _prometheus.QueryScalarAsync(
+            "(1 - (node_filesystem_avail_bytes{mountpoint=\"/\"} / node_filesystem_size_bytes{mountpoint=\"/\"})) * 100");
+        sb.AppendLine($"Disk Usage (/): **{diskResult ?? 0:F1}%**");
 
         // Load average
-        var loadQuery = "node_load1";
-        var loadResult = await QuerySingleValue(loadQuery);
-        sb.AppendLine($"Load (1m): **{loadResult:F2}**");
+        var loadResult = await _prometheus.QueryScalarAsync("node_load1");
+        sb.AppendLine($"Load (1m): **{loadResult ?? 0:F2}**");
 
         // Uptime
-        var uptimeQuery = "node_time_seconds - node_boot_time_seconds";
-        var uptimeResult = await QuerySingleValue(uptimeQuery);
-        var uptime = TimeSpan.FromSeconds(uptimeResult);
+        var uptimeResult = await _prometheus.QueryScalarAsync("node_time_seconds - node_boot_time_seconds");
+        var uptime = TimeSpan.FromSeconds(uptimeResult ?? 0);
         sb.AppendLine($"Uptime: **{uptime.Days}d {uptime.Hours}h {uptime.Minutes}m**");
 
         return sb.ToString();
@@ -179,18 +165,14 @@ public sealed class PrometheusPlugin
 
         try
         {
-            var response = await _httpClient.GetAsync($"{_baseUrl}/api/v1/targets");
-            response.EnsureSuccessStatusCode();
+            var targets = await _prometheus.GetTargetStatusesAsync();
 
-            var result = await response.Content.ReadFromJsonAsync<PrometheusTargetsResponse>();
-
-            if (result?.Data?.ActiveTargets == null || result.Data.ActiveTargets.Count == 0)
+            if (targets.Count == 0)
             {
                 return "No active targets found.";
             }
 
             var sb = new StringBuilder();
-            var targets = result.Data.ActiveTargets;
             var upCount = targets.Count(t => t.Health == "up");
             var downCount = targets.Count(t => t.Health == "down");
 
@@ -198,7 +180,7 @@ public sealed class PrometheusPlugin
             sb.AppendLine($"✅ Up: {upCount} | ❌ Down: {downCount}\n");
 
             var grouped = targets
-                .GroupBy(t => t.Labels?.GetValueOrDefault("job") ?? "unknown")
+                .GroupBy(t => t.Job)
                 .OrderBy(g => g.Key);
 
             foreach (var group in grouped)
@@ -210,8 +192,7 @@ public sealed class PrometheusPlugin
                 foreach (var target in group)
                 {
                     var status = target.Health == "up" ? "✅" : "❌";
-                    var instance = target.Labels?.GetValueOrDefault("instance") ?? target.ScrapeUrl ?? "unknown";
-                    sb.AppendLine($"   {status} {instance}");
+                    sb.AppendLine($"   {status} {target.Instance}");
                 }
             }
 
@@ -234,61 +215,35 @@ public sealed class PrometheusPlugin
         sb.AppendLine($"**Container Metrics: {containerName}**\n");
 
         // CPU usage rate
-        var cpuQuery = $"rate(container_cpu_usage_seconds_total{{name=\"{containerName}\"}}[5m]) * 100";
-        var cpuResult = await QuerySingleValue(cpuQuery);
-        sb.AppendLine($"CPU Usage: **{cpuResult:F2}%**");
+        var cpuResult = await _prometheus.QueryScalarAsync(
+            $"rate(container_cpu_usage_seconds_total{{name=\"{containerName}\"}}[5m]) * 100");
+        sb.AppendLine($"CPU Usage: **{cpuResult ?? 0:F2}%**");
 
         // Memory usage
-        var memQuery = $"container_memory_usage_bytes{{name=\"{containerName}\"}}";
-        var memResult = await QuerySingleValue(memQuery);
-        var memMB = memResult / (1024 * 1024);
+        var memResult = await _prometheus.QueryScalarAsync(
+            $"container_memory_usage_bytes{{name=\"{containerName}\"}}");
+        var memMB = (memResult ?? 0) / (1024 * 1024);
         sb.AppendLine($"Memory: **{memMB:F0} MB**");
 
         // Memory limit
-        var memLimitQuery = $"container_spec_memory_limit_bytes{{name=\"{containerName}\"}}";
-        var memLimitResult = await QuerySingleValue(memLimitQuery);
-        if (memLimitResult > 0)
+        var memLimitResult = await _prometheus.QueryScalarAsync(
+            $"container_spec_memory_limit_bytes{{name=\"{containerName}\"}}");
+        if (memLimitResult is > 0)
         {
-            var memLimitMB = memLimitResult / (1024 * 1024);
-            var memPercent = (memResult / memLimitResult) * 100;
+            var memLimitMB = memLimitResult.Value / (1024 * 1024);
+            var memPercent = ((memResult ?? 0) / memLimitResult.Value) * 100;
             sb.AppendLine($"Memory Limit: **{memLimitMB:F0} MB** ({memPercent:F1}% used)");
         }
 
         // Network I/O
-        var netRxQuery = $"rate(container_network_receive_bytes_total{{name=\"{containerName}\"}}[5m])";
-        var netRxResult = await QuerySingleValue(netRxQuery);
-        var netTxQuery = $"rate(container_network_transmit_bytes_total{{name=\"{containerName}\"}}[5m])";
-        var netTxResult = await QuerySingleValue(netTxQuery);
+        var netRxResult = await _prometheus.QueryScalarAsync(
+            $"rate(container_network_receive_bytes_total{{name=\"{containerName}\"}}[5m])");
+        var netTxResult = await _prometheus.QueryScalarAsync(
+            $"rate(container_network_transmit_bytes_total{{name=\"{containerName}\"}}[5m])");
 
-        sb.AppendLine($"Network: **{FormatBytes(netRxResult)}/s** in, **{FormatBytes(netTxResult)}/s** out");
+        sb.AppendLine($"Network: **{FormatBytes(netRxResult ?? 0)}/s** in, **{FormatBytes(netTxResult ?? 0)}/s** out");
 
         return sb.ToString();
-    }
-
-    private async Task<double> QuerySingleValue(string query)
-    {
-        try
-        {
-            var encodedQuery = Uri.EscapeDataString(query);
-            var response = await _httpClient.GetAsync($"{_baseUrl}/api/v1/query?query={encodedQuery}");
-            response.EnsureSuccessStatusCode();
-
-            var result = await response.Content.ReadFromJsonAsync<PrometheusQueryResponse>();
-
-            if (result?.Data?.Result?.FirstOrDefault()?.Value?.Length > 1)
-            {
-                if (double.TryParse(result.Data.Result[0].Value![1].ToString(), out var value))
-                {
-                    return value;
-                }
-            }
-
-            return 0;
-        }
-        catch
-        {
-            return 0;
-        }
     }
 
     private static string FormatLabels(Dictionary<string, string>? labels)
@@ -324,54 +279,5 @@ public sealed class PrometheusPlugin
         }
 
         return $"{bytes / (1024 * 1024 * 1024):F2} GB";
-    }
-
-    private sealed class PrometheusLabelResponse
-    {
-        public string Status { get; set; } = "";
-
-        public List<string> Data { get; set; } = [];
-    }
-
-    private sealed class PrometheusQueryResponse
-    {
-        public string Status { get; set; } = "";
-
-        public PrometheusQueryData? Data { get; set; }
-    }
-
-    private sealed class PrometheusQueryData
-    {
-        public string ResultType { get; set; } = "";
-
-        public List<PrometheusResult> Result { get; set; } = [];
-    }
-
-    private sealed class PrometheusResult
-    {
-        public Dictionary<string, string>? Metric { get; set; }
-
-        public JsonElement[]? Value { get; set; }
-    }
-
-    private sealed class PrometheusTargetsResponse
-    {
-        public string Status { get; set; } = "";
-
-        public PrometheusTargetsData? Data { get; set; }
-    }
-
-    private sealed class PrometheusTargetsData
-    {
-        public List<PrometheusTarget> ActiveTargets { get; set; } = [];
-    }
-
-    private sealed class PrometheusTarget
-    {
-        public Dictionary<string, string>? Labels { get; set; }
-
-        public string? ScrapeUrl { get; set; }
-
-        public string Health { get; set; } = "";
     }
 }

--- a/src/HomelabBot/Plugins/TrueNASPlugin.cs
+++ b/src/HomelabBot/Plugins/TrueNASPlugin.cs
@@ -3,6 +3,7 @@ using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text;
 using HomelabBot.Configuration;
+using HomelabBot.Models;
 using Microsoft.Extensions.Options;
 using Microsoft.SemanticKernel;
 
@@ -220,6 +221,30 @@ public sealed class TrueNASPlugin
         {
             _logger.LogError(ex, "Error getting system info");
             return $"Error getting system info: {ex.Message}";
+        }
+    }
+
+    internal async Task<List<PoolInfo>> GetPoolInfoAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            var response = await _httpClient.GetAsync($"{_baseUrl}/api/v2.0/pool", ct);
+            response.EnsureSuccessStatusCode();
+
+            var pools = await response.Content.ReadFromJsonAsync<List<TrueNASPool>>(ct);
+            return pools?.Select(p => new PoolInfo
+            {
+                Name = p.Name ?? "unknown",
+                Status = p.Status ?? "UNKNOWN",
+                Healthy = p.Healthy == true,
+                AllocatedBytes = p.Allocated ?? 0,
+                SizeBytes = p.Size ?? 0,
+            }).ToList() ?? [];
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to get pool info");
+            return [];
         }
     }
 

--- a/src/HomelabBot/Program.cs
+++ b/src/HomelabBot/Program.cs
@@ -146,6 +146,9 @@ try
     builder.Services.AddHttpClient("Default")
         .AddStandardResilienceHandler();
 
+    // Shared services
+    builder.Services.AddSingleton<PrometheusQueryService>();
+
     // Plugins
     builder.Services.AddSingleton<DockerPlugin>();
     builder.Services.AddSingleton<PrometheusPlugin>();

--- a/src/HomelabBot/Services/AnomalyDetectionService.cs
+++ b/src/HomelabBot/Services/AnomalyDetectionService.cs
@@ -13,15 +13,14 @@ namespace HomelabBot.Services;
 public sealed class AnomalyDetectionService : BackgroundService
 {
     private readonly IOptionsMonitor<AnomalyDetectionConfiguration> _config;
+    private readonly PrometheusQueryService _prometheus;
     private readonly HttpClient _httpClient;
-    private readonly string _prometheusUrl;
     private readonly SmartNotificationService _smartNotification;
     private readonly DiscordBotService _discordBot;
     private readonly IDbContextFactory<HomelabDbContext> _dbFactory;
     private readonly ILogger<AnomalyDetectionService> _logger;
     private readonly DockerPlugin _dockerPlugin;
-    private readonly string _trueNasUrl;
-    private readonly string _trueNasApiKey;
+    private readonly TrueNASPlugin _truenasPlugin;
     private readonly string _lokiUrl;
 
     private readonly ServiceStateStore _stateStore;
@@ -33,26 +32,25 @@ public sealed class AnomalyDetectionService : BackgroundService
     public AnomalyDetectionService(
         IOptionsMonitor<AnomalyDetectionConfiguration> config,
         IHttpClientFactory httpClientFactory,
-        IOptions<PrometheusConfiguration> prometheusConfig,
+        PrometheusQueryService prometheus,
         SmartNotificationService smartNotification,
         DiscordBotService discordBot,
         IDbContextFactory<HomelabDbContext> dbFactory,
         ILogger<AnomalyDetectionService> logger,
         DockerPlugin dockerPlugin,
-        IOptions<TrueNASConfiguration> trueNasConfig,
+        TrueNASPlugin truenasPlugin,
         IOptions<LokiConfiguration> lokiConfig,
         ServiceStateStore stateStore)
     {
         _config = config;
         _httpClient = httpClientFactory.CreateClient("Default");
-        _prometheusUrl = prometheusConfig.Value.Host.TrimEnd('/');
+        _prometheus = prometheus;
         _smartNotification = smartNotification;
         _discordBot = discordBot;
         _dbFactory = dbFactory;
         _logger = logger;
         _dockerPlugin = dockerPlugin;
-        _trueNasUrl = trueNasConfig.Value.Host.TrimEnd('/');
-        _trueNasApiKey = trueNasConfig.Value.ApiKey;
+        _truenasPlugin = truenasPlugin;
         _lokiUrl = lokiConfig.Value.Host.TrimEnd('/');
         _stateStore = stateStore;
     }
@@ -147,7 +145,7 @@ public sealed class AnomalyDetectionService : BackgroundService
     {
         var anomalies = new List<Anomaly>();
 
-        var cpuUsage = await QueryPrometheusValueAsync(
+        var cpuUsage = await _prometheus.QueryScalarAsync(
             "100 - (avg(rate(node_cpu_seconds_total{mode=\"idle\"}[5m])) * 100)", ct);
 
         if (cpuUsage == null)
@@ -186,7 +184,7 @@ public sealed class AnomalyDetectionService : BackgroundService
     {
         var anomalies = new List<Anomaly>();
 
-        var memUsage = await QueryPrometheusValueAsync(
+        var memUsage = await _prometheus.QueryScalarAsync(
             "(1 - node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes) * 100", ct);
 
         if (memUsage == null)
@@ -212,7 +210,7 @@ public sealed class AnomalyDetectionService : BackgroundService
     {
         var anomalies = new List<Anomaly>();
 
-        var diskUsage = await QueryPrometheusValueAsync(
+        var diskUsage = await _prometheus.QueryScalarAsync(
             "(1 - node_filesystem_avail_bytes{mountpoint=\"/\"} / node_filesystem_size_bytes{mountpoint=\"/\"}) * 100", ct);
 
         if (diskUsage == null)
@@ -232,7 +230,7 @@ public sealed class AnomalyDetectionService : BackgroundService
         }
 
         // Check disk fill rate prediction (ratio < 0 means available space crosses zero within 30 days)
-        var predictedAvailableRatio = await QueryPrometheusValueAsync(
+        var predictedAvailableRatio = await _prometheus.QueryScalarAsync(
             "predict_linear(node_filesystem_avail_bytes{mountpoint=\"/\"}[7d], 30*24*3600) / node_filesystem_size_bytes{mountpoint=\"/\"}", ct);
 
         if (predictedAvailableRatio is < 0)
@@ -255,28 +253,8 @@ public sealed class AnomalyDetectionService : BackgroundService
 
         try
         {
-            var response = await _httpClient.GetAsync($"{_prometheusUrl}/api/v1/targets", ct);
-            if (!response.IsSuccessStatusCode)
-            {
-                return anomalies;
-            }
-
-            var json = await response.Content.ReadAsStringAsync(ct);
-            using var doc = JsonDocument.Parse(json);
-
-            var targets = doc.RootElement
-                .GetProperty("data")
-                .GetProperty("activeTargets");
-
-            var downTargets = new List<string>();
-            foreach (var target in targets.EnumerateArray())
-            {
-                if (target.GetProperty("health").GetString() == "down")
-                {
-                    var job = target.GetProperty("labels").GetProperty("job").GetString() ?? "unknown";
-                    downTargets.Add(job);
-                }
-            }
+            var targets = await _prometheus.GetTargetStatusesAsync(ct);
+            var downTargets = targets.Where(t => t.Health == "down").Select(t => t.Job).ToList();
 
             if (downTargets.Count > 0)
             {
@@ -328,7 +306,7 @@ public sealed class AnomalyDetectionService : BackgroundService
         var anomalies = new List<Anomaly>();
         try
         {
-            var restartRate = await QueryPrometheusValueAsync(
+            var restartRate = await _prometheus.QueryScalarAsync(
                 "sum(increase(container_restart_count{name!=\"\"}[5m]))", ct);
             if (restartRate is > 0)
             {
@@ -354,7 +332,7 @@ public sealed class AnomalyDetectionService : BackgroundService
         var anomalies = new List<Anomaly>();
         try
         {
-            var cpuLoad = await QueryPrometheusValueAsync("mktxp_system_cpu_load", ct);
+            var cpuLoad = await _prometheus.QueryScalarAsync("mktxp_system_cpu_load", ct);
             if (cpuLoad is > 80)
             {
                 anomalies.Add(new Anomaly
@@ -366,7 +344,7 @@ public sealed class AnomalyDetectionService : BackgroundService
                 });
             }
 
-            var temp = await QueryPrometheusValueAsync("mktxp_system_cpu_temperature", ct);
+            var temp = await _prometheus.QueryScalarAsync("mktxp_system_cpu_temperature", ct);
             if (temp is > 75)
             {
                 anomalies.Add(new Anomaly
@@ -378,8 +356,8 @@ public sealed class AnomalyDetectionService : BackgroundService
                 });
             }
 
-            var memTotal = await QueryPrometheusValueAsync("mktxp_system_total_memory", ct);
-            var memFree = await QueryPrometheusValueAsync("mktxp_system_free_memory", ct);
+            var memTotal = await _prometheus.QueryScalarAsync("mktxp_system_total_memory", ct);
+            var memFree = await _prometheus.QueryScalarAsync("mktxp_system_free_memory", ct);
             if (memTotal is > 0)
             {
                 var memUsedPct = ((memTotal.Value - (memFree ?? 0)) / memTotal.Value) * 100;
@@ -408,7 +386,7 @@ public sealed class AnomalyDetectionService : BackgroundService
         var anomalies = new List<Anomaly>();
         try
         {
-            var rxRate = await QueryPrometheusValueAsync(
+            var rxRate = await _prometheus.QueryScalarAsync(
                 "sum(rate(mktxp_interface_rx_byte[5m]))", ct);
             if (rxRate == null)
             {
@@ -443,34 +421,17 @@ public sealed class AnomalyDetectionService : BackgroundService
         var anomalies = new List<Anomaly>();
         try
         {
-            using var request = new HttpRequestMessage(HttpMethod.Get, $"{_trueNasUrl}/api/v2.0/pool");
-            if (!string.IsNullOrEmpty(_trueNasApiKey))
+            var pools = await _truenasPlugin.GetPoolInfoAsync(ct);
+
+            foreach (var pool in pools)
             {
-                request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", _trueNasApiKey);
-            }
-
-            var response = await _httpClient.SendAsync(request, ct);
-            if (!response.IsSuccessStatusCode)
-            {
-                return anomalies;
-            }
-
-            var json = await response.Content.ReadAsStringAsync(ct);
-            using var doc = JsonDocument.Parse(json);
-
-            foreach (var pool in doc.RootElement.EnumerateArray())
-            {
-                var name = pool.GetProperty("name").GetString() ?? "unknown";
-                var status = pool.GetProperty("status").GetString() ?? "UNKNOWN";
-                var healthy = pool.TryGetProperty("healthy", out var h) && h.GetBoolean();
-
-                if (status != "ONLINE" || !healthy)
+                if (pool.Status != "ONLINE" || !pool.Healthy)
                 {
                     anomalies.Add(new Anomaly
                     {
                         Type = "Storage",
-                        Message = $"Pool '{name}' status: {status} (healthy: {healthy})",
-                        Severity = status == "DEGRADED" ? AnomalySeverity.Warning : AnomalySeverity.Critical,
+                        Message = $"Pool '{pool.Name}' status: {pool.Status} (healthy: {pool.Healthy})",
+                        Severity = pool.Status == "DEGRADED" ? AnomalySeverity.Warning : AnomalySeverity.Critical,
                         Value = 0,
                     });
                 }
@@ -489,7 +450,7 @@ public sealed class AnomalyDetectionService : BackgroundService
         var anomalies = new List<Anomaly>();
         try
         {
-            var errorRate = await QueryPrometheusValueAsync(
+            var errorRate = await _prometheus.QueryScalarAsync(
                 "sum(rate(traefik_service_requests_total{code=~\"5..\"}[5m])) / sum(rate(traefik_service_requests_total[5m])) * 100", ct);
 
             if (errorRate is > 5)
@@ -516,7 +477,7 @@ public sealed class AnomalyDetectionService : BackgroundService
         var anomalies = new List<Anomaly>();
         try
         {
-            var minExpiry = await QueryPrometheusValueAsync(
+            var minExpiry = await _prometheus.QueryScalarAsync(
                 "min(traefik_tls_certs_not_after - time())", ct);
 
             if (minExpiry == null)
@@ -549,7 +510,7 @@ public sealed class AnomalyDetectionService : BackgroundService
         var anomalies = new List<Anomaly>();
         try
         {
-            var headSeries = await QueryPrometheusValueAsync("prometheus_tsdb_head_series", ct);
+            var headSeries = await _prometheus.QueryScalarAsync("prometheus_tsdb_head_series", ct);
             if (headSeries is > 500_000)
             {
                 anomalies.Add(new Anomaly
@@ -647,47 +608,6 @@ public sealed class AnomalyDetectionService : BackgroundService
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Failed to record anomaly event");
-        }
-    }
-
-    private async Task<double?> QueryPrometheusValueAsync(string query, CancellationToken ct)
-    {
-        try
-        {
-            var encodedQuery = Uri.EscapeDataString(query);
-            var response = await _httpClient.GetAsync(
-                $"{_prometheusUrl}/api/v1/query?query={encodedQuery}", ct);
-
-            if (!response.IsSuccessStatusCode)
-            {
-                return null;
-            }
-
-            var json = await response.Content.ReadAsStringAsync(ct);
-            using var doc = JsonDocument.Parse(json);
-
-            var results = doc.RootElement
-                .GetProperty("data")
-                .GetProperty("result");
-
-            if (results.GetArrayLength() == 0)
-            {
-                return null;
-            }
-
-            var valueStr = results[0].GetProperty("value")[1].GetString();
-            if (double.TryParse(valueStr, System.Globalization.NumberStyles.Float,
-                    System.Globalization.CultureInfo.InvariantCulture, out var value))
-            {
-                return value;
-            }
-
-            return null;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogDebug(ex, "Failed to query Prometheus: {Query}", query);
-            return null;
         }
     }
 

--- a/src/HomelabBot/Services/IncidentSimilarityService.cs
+++ b/src/HomelabBot/Services/IncidentSimilarityService.cs
@@ -27,11 +27,7 @@ public sealed class IncidentSimilarityService
     {
         await using var db = await _dbFactory.CreateDbContextAsync(ct);
 
-        var keywords = symptom.ToLowerInvariant()
-            .Split(' ', StringSplitOptions.RemoveEmptyEntries)
-            .Where(k => k.Length > 2)
-            .Distinct()
-            .ToArray();
+        var keywords = KeywordMatcher.Tokenize(symptom).ToArray();
 
         if (keywords.Length == 0)
         {

--- a/src/HomelabBot/Services/KeywordMatcher.cs
+++ b/src/HomelabBot/Services/KeywordMatcher.cs
@@ -1,0 +1,46 @@
+namespace HomelabBot.Services;
+
+public static class KeywordMatcher
+{
+    public static List<string> Tokenize(string text, int minLength = 3)
+    {
+        return text.ToLowerInvariant()
+            .Split(' ', StringSplitOptions.RemoveEmptyEntries)
+            .Where(k => k.Length >= minLength)
+            .Distinct()
+            .ToList();
+    }
+
+    public static double Score(string query, string target, int minKeywordLength = 3)
+    {
+        var keywords = Tokenize(query, minKeywordLength);
+        if (keywords.Count == 0)
+        {
+            return 0;
+        }
+
+        var targetLower = target.ToLowerInvariant();
+        var targetWords = targetLower.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+
+        var score = 0.0;
+        foreach (var keyword in keywords)
+        {
+            if (targetWords.Contains(keyword))
+            {
+                score += 2;
+            }
+            else if (targetLower.Contains(keyword))
+            {
+                score += 1;
+            }
+        }
+
+        return score;
+    }
+
+    public static int CountMatches(string[] keywords, string target)
+    {
+        var targetLower = target.ToLowerInvariant();
+        return keywords.Count(k => targetLower.Contains(k));
+    }
+}

--- a/src/HomelabBot/Services/KnowledgeService.cs
+++ b/src/HomelabBot/Services/KnowledgeService.cs
@@ -333,8 +333,7 @@ public sealed class KnowledgeService
         matchedTopics ??= [];
 
         // Fallback: substring matching for obvious cases LLM might miss
-        var queryLower = naturalQuery.ToLowerInvariant();
-        var queryWords = queryLower.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        var queryWords = KeywordMatcher.Tokenize(naturalQuery);
 
         foreach (var topic in allTopics)
         {
@@ -346,14 +345,8 @@ public sealed class KnowledgeService
             var topicLower = topic.ToLowerInvariant();
             var topicParts = topicLower.Split(':');
 
-            // Check if any query word matches topic or topic parts
             foreach (var word in queryWords)
             {
-                if (word.Length < 3)
-                {
-                    continue; // Skip short words like "on", "is", etc.
-                }
-
                 if (topicLower.Contains(word) || topicParts.Any(p => p.Contains(word) || word.Contains(p)))
                 {
                     matchedTopics.Add(topic);

--- a/src/HomelabBot/Services/MemoryService.cs
+++ b/src/HomelabBot/Services/MemoryService.cs
@@ -52,6 +52,21 @@ public sealed class MemoryService
             .FirstOrDefaultAsync();
     }
 
+    public async Task<Dictionary<int, Investigation>> GetInvestigationsByIdsAsync(List<int> ids)
+    {
+        if (ids.Count == 0)
+        {
+            return new Dictionary<int, Investigation>();
+        }
+
+        await using var db = await _dbFactory.CreateDbContextAsync();
+
+        return await db.Investigations
+            .Include(i => i.Steps)
+            .Where(i => ids.Contains(i.Id))
+            .ToDictionaryAsync(i => i.Id);
+    }
+
     public async Task<Investigation?> GetInvestigationByIdAsync(int id)
     {
         await using var db = await _dbFactory.CreateDbContextAsync();

--- a/src/HomelabBot/Services/MemoryService.cs
+++ b/src/HomelabBot/Services/MemoryService.cs
@@ -10,15 +10,18 @@ public sealed class MemoryService
     private readonly IDbContextFactory<HomelabDbContext> _dbFactory;
     private readonly ILogger<MemoryService> _logger;
     private readonly RunbookCompilerService _runbookCompiler;
+    private readonly IncidentSimilarityService _similarityService;
 
     public MemoryService(
         IDbContextFactory<HomelabDbContext> dbFactory,
         ILogger<MemoryService> logger,
-        RunbookCompilerService runbookCompiler)
+        RunbookCompilerService runbookCompiler,
+        IncidentSimilarityService similarityService)
     {
         _dbFactory = dbFactory;
         _logger = logger;
         _runbookCompiler = runbookCompiler;
+        _similarityService = similarityService;
     }
 
     public async Task<Investigation> StartInvestigationAsync(ulong threadId, string trigger)
@@ -140,48 +143,13 @@ public sealed class MemoryService
         return investigation;
     }
 
-    public async Task<List<Investigation>> SearchPastIncidentsAsync(string symptom, int limit = 5)
-    {
-        await using var db = await _dbFactory.CreateDbContextAsync();
-
-        var keywords = symptom.ToLowerInvariant().Split(' ', StringSplitOptions.RemoveEmptyEntries);
-
-        var investigations = await db.Investigations
-            .Include(i => i.Steps)
-            .Where(i => i.Resolved)
-            .OrderByDescending(i => i.StartedAt)
-            .Take(50)
-            .ToListAsync();
-
-        // Simple keyword matching for relevance
-        var scored = investigations
-            .Select(i => new
-            {
-                Investigation = i,
-                Score = keywords.Count(k =>
-                    i.Trigger.Contains(k, StringComparison.OrdinalIgnoreCase) ||
-                    (i.Resolution?.Contains(k, StringComparison.OrdinalIgnoreCase) ?? false))
-            })
-            .Where(x => x.Score > 0)
-            .OrderByDescending(x => x.Score)
-            .ThenByDescending(x => x.Investigation.StartedAt)
-            .Take(limit)
-            .Select(x => x.Investigation)
-            .ToList();
-
-        return scored;
-    }
-
     public async Task<List<Pattern>> GetRelevantPatternsAsync(string symptom, int limit = 3)
     {
         await using var db = await _dbFactory.CreateDbContextAsync();
 
-        var keywords = symptom.ToLowerInvariant()
-            .Split(' ', StringSplitOptions.RemoveEmptyEntries)
-            .Where(k => k.Length > 2)
-            .ToArray();
+        var keywords = KeywordMatcher.Tokenize(symptom);
 
-        if (keywords.Length == 0)
+        if (keywords.Count == 0)
         {
             return [];
         }
@@ -194,25 +162,11 @@ public sealed class MemoryService
         var scored = patterns
             .Select(p =>
             {
-                var symptomLower = p.Symptom.ToLowerInvariant();
-                var symptomWords = symptomLower.Split(' ');
-                var keywordScore = 0;
-
-                foreach (var keyword in keywords)
-                {
-                    if (symptomWords.Contains(keyword))
-                    {
-                        keywordScore += 2;
-                    }
-                    else if (symptomLower.Contains(keyword))
-                    {
-                        keywordScore += 1;
-                    }
-                }
+                var keywordScore = KeywordMatcher.Score(symptom, p.Symptom);
 
                 if (keywordScore == 0)
                 {
-                    return new { Pattern = p, Score = 0 };
+                    return new { Pattern = p, Score = 0.0 };
                 }
 
                 // Frequency bonus only when there's a keyword match
@@ -255,10 +209,10 @@ public sealed class MemoryService
 
     public async Task<string> GenerateIncidentContextAsync(string symptom)
     {
-        var pastIncidents = await SearchPastIncidentsAsync(symptom);
+        var similarIncidents = await _similarityService.FindSimilarAsync(symptom);
         var patterns = await GetRelevantPatternsAsync(symptom);
 
-        if (pastIncidents.Count == 0 && patterns.Count == 0)
+        if (similarIncidents.Count == 0 && patterns.Count == 0)
         {
             return string.Empty;
         }
@@ -282,14 +236,14 @@ public sealed class MemoryService
             }
         }
 
-        if (pastIncidents.Count > 0)
+        if (similarIncidents.Count > 0)
         {
             sb.AppendLine("\n### Similar Past Issues");
-            foreach (var i in pastIncidents)
+            foreach (var i in similarIncidents)
             {
-                var age = DateTime.UtcNow - i.StartedAt;
+                var age = DateTime.UtcNow - i.OccurredAt;
                 var timeAgo = age.TotalDays > 1 ? $"{(int)age.TotalDays}d ago" : $"{(int)age.TotalHours}h ago";
-                sb.AppendLine($"- [{timeAgo}] {i.Trigger}");
+                sb.AppendLine($"- [{timeAgo}] {i.Trigger} ({i.SimilarityScore:F0}% match)");
                 if (!string.IsNullOrEmpty(i.Resolution))
                 {
                     sb.AppendLine($"  Resolved: {i.Resolution}");

--- a/src/HomelabBot/Services/PrometheusQueryService.cs
+++ b/src/HomelabBot/Services/PrometheusQueryService.cs
@@ -94,7 +94,9 @@ public sealed class PrometheusQueryService
                     var value = 0.0;
                     if (item.Value?.Length > 1)
                     {
-                        double.TryParse(item.Value[1].ToString(), out value);
+                        double.TryParse(item.Value[1].ToString(),
+                            System.Globalization.NumberStyles.Float,
+                            System.Globalization.CultureInfo.InvariantCulture, out value);
                     }
 
                     results.Add(new MetricResult

--- a/src/HomelabBot/Services/PrometheusQueryService.cs
+++ b/src/HomelabBot/Services/PrometheusQueryService.cs
@@ -1,0 +1,176 @@
+using System.Net.Http.Json;
+using HomelabBot.Configuration;
+using HomelabBot.Models.Prometheus;
+using Microsoft.Extensions.Options;
+
+namespace HomelabBot.Services;
+
+public sealed class PrometheusQueryService
+{
+    private readonly HttpClient _httpClient;
+    private readonly ILogger<PrometheusQueryService> _logger;
+    private readonly string _baseUrl;
+
+    public PrometheusQueryService(
+        IHttpClientFactory httpClientFactory,
+        IOptions<PrometheusConfiguration> config,
+        ILogger<PrometheusQueryService> logger)
+    {
+        _httpClient = httpClientFactory.CreateClient("Default");
+        _logger = logger;
+        _baseUrl = config.Value.Host.TrimEnd('/');
+    }
+
+    public async Task<double?> QueryScalarAsync(string query, CancellationToken ct = default)
+    {
+        try
+        {
+            var encodedQuery = Uri.EscapeDataString(query);
+            var response = await _httpClient.GetAsync(
+                $"{_baseUrl}/api/v1/query?query={encodedQuery}", ct);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogDebug("Prometheus query failed with {Status}: {Query}",
+                    response.StatusCode, query);
+                return null;
+            }
+
+            var result = await response.Content.ReadFromJsonAsync<PrometheusQueryResponse>(ct);
+
+            if (result?.Data?.Result?.FirstOrDefault()?.Value?.Length > 1)
+            {
+                var valueStr = result.Data.Result[0].Value![1].ToString();
+                if (double.TryParse(valueStr, System.Globalization.NumberStyles.Float,
+                        System.Globalization.CultureInfo.InvariantCulture, out var value))
+                {
+                    return value;
+                }
+            }
+
+            return null;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Failed to query Prometheus: {Query}", query);
+            return null;
+        }
+    }
+
+    public async Task<PrometheusQueryResponse?> QueryAsync(string query, CancellationToken ct = default)
+    {
+        try
+        {
+            var encodedQuery = Uri.EscapeDataString(query);
+            var response = await _httpClient.GetAsync(
+                $"{_baseUrl}/api/v1/query?query={encodedQuery}", ct);
+            response.EnsureSuccessStatusCode();
+
+            return await response.Content.ReadFromJsonAsync<PrometheusQueryResponse>(ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Failed to query Prometheus: {Query}", query);
+            return null;
+        }
+    }
+
+    public async Task<List<MetricResult>> QueryMultipleAsync(string query, CancellationToken ct = default)
+    {
+        var results = new List<MetricResult>();
+
+        try
+        {
+            var encodedQuery = Uri.EscapeDataString(query);
+            var response = await _httpClient.GetAsync(
+                $"{_baseUrl}/api/v1/query?query={encodedQuery}", ct);
+            response.EnsureSuccessStatusCode();
+
+            var result = await response.Content.ReadFromJsonAsync<PrometheusQueryResponse>(ct);
+            if (result?.Data?.Result != null)
+            {
+                foreach (var item in result.Data.Result)
+                {
+                    var value = 0.0;
+                    if (item.Value?.Length > 1)
+                    {
+                        double.TryParse(item.Value[1].ToString(), out value);
+                    }
+
+                    results.Add(new MetricResult
+                    {
+                        Labels = item.Metric ?? [],
+                        Value = value
+                    });
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Failed to query Prometheus multiple: {Query}", query);
+        }
+
+        return results;
+    }
+
+    public async Task<List<PrometheusTargetInfo>> GetTargetStatusesAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            var response = await _httpClient.GetAsync($"{_baseUrl}/api/v1/targets", ct);
+            response.EnsureSuccessStatusCode();
+
+            var result = await response.Content.ReadFromJsonAsync<PrometheusTargetsResponse>(ct);
+            var targets = result?.Data?.ActiveTargets ?? [];
+
+            return targets.Select(t => new PrometheusTargetInfo
+            {
+                Job = t.Labels?.GetValueOrDefault("job") ?? "unknown",
+                Instance = t.Labels?.GetValueOrDefault("instance") ?? t.ScrapeUrl ?? "unknown",
+                Health = t.Health
+            }).ToList();
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Failed to get Prometheus targets");
+            return [];
+        }
+    }
+
+    public async Task<PrometheusQueryRangeResponse?> QueryRangeAsync(
+        string query, long startUnix, long endUnix, int stepSeconds, CancellationToken ct = default)
+    {
+        try
+        {
+            var encodedQuery = Uri.EscapeDataString(query);
+            var response = await _httpClient.GetAsync(
+                $"{_baseUrl}/api/v1/query_range?query={encodedQuery}&start={startUnix}&end={endUnix}&step={stepSeconds}", ct);
+            response.EnsureSuccessStatusCode();
+
+            return await response.Content.ReadFromJsonAsync<PrometheusQueryRangeResponse>(ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Failed to query Prometheus range: {Query}", query);
+            return null;
+        }
+    }
+
+    public async Task<PrometheusLabelResponse?> GetLabelValuesAsync(
+        string label, CancellationToken ct = default)
+    {
+        try
+        {
+            var response = await _httpClient.GetAsync(
+                $"{_baseUrl}/api/v1/label/{Uri.EscapeDataString(label)}/values", ct);
+            response.EnsureSuccessStatusCode();
+
+            return await response.Content.ReadFromJsonAsync<PrometheusLabelResponse>(ct);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "Failed to get label values for {Label}", label);
+            return null;
+        }
+    }
+}

--- a/src/HomelabBot/Services/RunbookCompilerService.cs
+++ b/src/HomelabBot/Services/RunbookCompilerService.cs
@@ -141,10 +141,7 @@ public sealed class RunbookCompilerService
     private static async Task<Runbook?> FindSimilarRunbookAsync(
         HomelabDbContext db, string trigger, CancellationToken ct)
     {
-        var keywords = trigger.ToLowerInvariant()
-            .Split(' ', StringSplitOptions.RemoveEmptyEntries)
-            .Where(k => k.Length > 2)
-            .ToArray();
+        var keywords = KeywordMatcher.Tokenize(trigger).ToArray();
 
         if (keywords.Length == 0)
         {
@@ -157,8 +154,7 @@ public sealed class RunbookCompilerService
 
         return runbooks.FirstOrDefault(r =>
         {
-            var triggerLower = r.TriggerCondition.ToLowerInvariant();
-            var matchCount = keywords.Count(k => triggerLower.Contains(k));
+            var matchCount = KeywordMatcher.CountMatches(keywords, r.TriggerCondition);
             return matchCount >= Math.Max(2, (keywords.Length + 1) / 2);
         });
     }

--- a/src/HomelabBot/Services/RunbookTriggerService.cs
+++ b/src/HomelabBot/Services/RunbookTriggerService.cs
@@ -88,10 +88,10 @@ public sealed class RunbookTriggerService
         }
 
         // Keyword match against alert name and description
-        var keywords = trigger.ToLowerInvariant().Split(' ', StringSplitOptions.RemoveEmptyEntries);
-        var alertText = $"{alert.AlertName} {alert.Description ?? ""} {alert.Summary ?? ""}".ToLowerInvariant();
+        var keywords = KeywordMatcher.Tokenize(trigger, minLength: 1);
+        var alertText = $"{alert.AlertName} {alert.Description ?? ""} {alert.Summary ?? ""}";
 
-        return keywords.Length > 0 && keywords.All(k => alertText.Contains(k));
+        return keywords.Count > 0 && keywords.All(k => alertText.Contains(k, StringComparison.OrdinalIgnoreCase));
     }
 
     public async Task SeedDefaultRunbooksAsync(CancellationToken ct = default)

--- a/src/HomelabBot/Services/SummaryDataAggregator.cs
+++ b/src/HomelabBot/Services/SummaryDataAggregator.cs
@@ -1,35 +1,29 @@
-using System.Net.Http.Headers;
-using System.Net.Http.Json;
-using System.Text.Json;
 using Docker.DotNet;
 using Docker.DotNet.Models;
-using HomelabBot.Configuration;
 using HomelabBot.Models;
-using Microsoft.Extensions.Options;
+using HomelabBot.Plugins;
 
 namespace HomelabBot.Services;
 
 public sealed class SummaryDataAggregator
 {
-    private readonly HttpClient _httpClient;
+    private readonly PrometheusQueryService _prometheus;
+    private readonly MikroTikPlugin _mikrotikPlugin;
+    private readonly TrueNASPlugin _truenasPlugin;
     private readonly ILogger<SummaryDataAggregator> _logger;
-    private readonly string _prometheusUrl;
-    private readonly string _truenasUrl;
-    private readonly string? _truenasApiKey;
     private readonly HealthScoreService _healthScoreService;
 
     public SummaryDataAggregator(
-        IHttpClientFactory httpClientFactory,
-        IOptions<PrometheusConfiguration> prometheusConfig,
-        IOptions<TrueNASConfiguration> truenasConfig,
+        PrometheusQueryService prometheus,
+        MikroTikPlugin mikrotikPlugin,
+        TrueNASPlugin truenasPlugin,
         HealthScoreService healthScoreService,
         ILogger<SummaryDataAggregator> logger)
     {
-        _httpClient = httpClientFactory.CreateClient("Default");
+        _prometheus = prometheus;
+        _mikrotikPlugin = mikrotikPlugin;
+        _truenasPlugin = truenasPlugin;
         _logger = logger;
-        _prometheusUrl = prometheusConfig.Value.Host.TrimEnd('/');
-        _truenasUrl = truenasConfig.Value.Host.TrimEnd('/');
-        _truenasApiKey = truenasConfig.Value.ApiKey;
         _healthScoreService = healthScoreService;
     }
 
@@ -70,19 +64,14 @@ public sealed class SummaryDataAggregator
     {
         try
         {
-            // Query Prometheus for alerts that fired in the last 24h
-            var query = Uri.EscapeDataString("ALERTS{alertstate=\"firing\"}");
             var endTime = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
             var startTime = endTime - 86400; // 24 hours ago
 
-            var response = await _httpClient.GetAsync(
-                $"{_prometheusUrl}/api/v1/query_range?query={query}&start={startTime}&end={endTime}&step=300", ct);
-            response.EnsureSuccessStatusCode();
+            var result = await _prometheus.QueryRangeAsync(
+                "ALERTS{alertstate=\"firing\"}", startTime, endTime, 300, ct);
 
-            var result = await response.Content.ReadFromJsonAsync<PrometheusQueryRangeResponse>(ct);
             var alertResults = result?.Data?.Result ?? [];
 
-            // Deduplicate by alertname - each unique alert that fired in the period
             var alerts = alertResults
                 .Select(r => new AlertSummary
                 {
@@ -131,29 +120,21 @@ public sealed class SummaryDataAggregator
     {
         try
         {
-            using var request = new HttpRequestMessage(HttpMethod.Get, $"{_truenasUrl}/api/v2.0/pool");
-            if (!string.IsNullOrEmpty(_truenasApiKey))
-            {
-                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _truenasApiKey);
-            }
+            var poolInfos = await _truenasPlugin.GetPoolInfoAsync(ct);
 
-            var response = await _httpClient.SendAsync(request, ct);
-            response.EnsureSuccessStatusCode();
-
-            var pools = await response.Content.ReadFromJsonAsync<List<TrueNASPool>>(ct);
-            return pools?.Select(p =>
+            return poolInfos.Select(p =>
             {
-                var allocatedTB = (p.Allocated ?? 0) / (1024.0 * 1024 * 1024 * 1024);
-                var sizeTB = (p.Size ?? 0) / (1024.0 * 1024 * 1024 * 1024);
+                var allocatedTB = p.AllocatedBytes / (1024.0 * 1024 * 1024 * 1024);
+                var sizeTB = p.SizeBytes / (1024.0 * 1024 * 1024 * 1024);
                 var usedPercent = sizeTB > 0 ? (allocatedTB / sizeTB) * 100 : 0;
 
                 return new PoolStatus
                 {
-                    Name = p.Name ?? "unknown",
-                    Health = p.Status ?? "unknown",
+                    Name = p.Name,
+                    Health = p.Status,
                     UsedPercent = usedPercent
                 };
-            }).ToList() ?? [];
+            }).ToList();
         }
         catch (Exception ex)
         {
@@ -166,18 +147,13 @@ public sealed class SummaryDataAggregator
     {
         try
         {
-            var cpuLoad = await QueryPrometheusValue("mktxp_system_cpu_load", ct);
-            var memTotal = await QueryPrometheusValue("mktxp_system_total_memory", ct);
-            var memFree = await QueryPrometheusValue("mktxp_system_free_memory", ct);
-            var uptimeSeconds = await QueryPrometheusValue("mktxp_system_uptime", ct);
-
-            var memUsedPercent = memTotal > 0 ? ((memTotal - memFree) / memTotal) * 100 : 0;
+            var metrics = await _mikrotikPlugin.GetRouterMetricsAsync(ct);
 
             return new RouterStatus
             {
-                CpuPercent = cpuLoad,
-                MemoryPercent = memUsedPercent,
-                Uptime = TimeSpan.FromSeconds(uptimeSeconds)
+                CpuPercent = metrics.CpuLoad,
+                MemoryPercent = metrics.MemoryPercent,
+                Uptime = metrics.Uptime
             };
         }
         catch (Exception ex)
@@ -191,11 +167,7 @@ public sealed class SummaryDataAggregator
     {
         try
         {
-            var response = await _httpClient.GetAsync($"{_prometheusUrl}/api/v1/targets", ct);
-            response.EnsureSuccessStatusCode();
-
-            var result = await response.Content.ReadFromJsonAsync<PrometheusTargetsResponse>(ct);
-            var targets = result?.Data?.ActiveTargets ?? [];
+            var targets = await _prometheus.GetTargetStatusesAsync(ct);
 
             return new MonitoringStatus
             {
@@ -209,87 +181,5 @@ public sealed class SummaryDataAggregator
             _logger.LogWarning(ex, "Failed to fetch monitoring status");
             return null;
         }
-    }
-
-    private async Task<double> QueryPrometheusValue(string metric, CancellationToken ct)
-    {
-        try
-        {
-            var encodedQuery = Uri.EscapeDataString(metric);
-            var response = await _httpClient.GetAsync($"{_prometheusUrl}/api/v1/query?query={encodedQuery}", ct);
-            response.EnsureSuccessStatusCode();
-
-            var result = await response.Content.ReadFromJsonAsync<PrometheusQueryResponse>(ct);
-            if (result?.Data?.Result?.FirstOrDefault()?.Value?.Length > 1)
-            {
-                if (double.TryParse(result.Data.Result[0].Value![1].ToString(), out var value))
-                {
-                    return value;
-                }
-            }
-
-            return 0;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogDebug(ex, "Failed to query Prometheus metric {Metric}", metric);
-            return 0;
-        }
-    }
-
-    private sealed class TrueNASPool
-    {
-        public string? Name { get; set; }
-
-        public string? Status { get; set; }
-
-        public long? Size { get; set; }
-
-        public long? Allocated { get; set; }
-    }
-
-    private sealed class PrometheusTargetsResponse
-    {
-        public PrometheusTargetsData? Data { get; set; }
-    }
-
-    private sealed class PrometheusTargetsData
-    {
-        public List<PrometheusTarget> ActiveTargets { get; set; } = [];
-    }
-
-    private sealed class PrometheusTarget
-    {
-        public string Health { get; set; } = "";
-    }
-
-    private sealed class PrometheusQueryResponse
-    {
-        public PrometheusQueryData? Data { get; set; }
-    }
-
-    private sealed class PrometheusQueryData
-    {
-        public List<PrometheusResult>? Result { get; set; }
-    }
-
-    private sealed class PrometheusResult
-    {
-        public JsonElement[]? Value { get; set; }
-    }
-
-    private sealed class PrometheusQueryRangeResponse
-    {
-        public PrometheusQueryRangeData? Data { get; set; }
-    }
-
-    private sealed class PrometheusQueryRangeData
-    {
-        public List<PrometheusRangeResult>? Result { get; set; }
-    }
-
-    private sealed class PrometheusRangeResult
-    {
-        public Dictionary<string, string>? Metric { get; set; }
     }
 }

--- a/tests/HomelabBot.Tests/MemoryServiceTests.cs
+++ b/tests/HomelabBot.Tests/MemoryServiceTests.cs
@@ -14,10 +14,14 @@ public class MemoryServiceTests : IClassFixture<DatabaseFixture>
         var runbookCompiler = new RunbookCompilerService(
             _fixture.DbContextFactory,
             NullLogger<RunbookCompilerService>.Instance);
+        var similarityService = new IncidentSimilarityService(
+            _fixture.DbContextFactory,
+            NullLogger<IncidentSimilarityService>.Instance);
         _service = new MemoryService(
             _fixture.DbContextFactory,
             NullLogger<MemoryService>.Instance,
-            runbookCompiler);
+            runbookCompiler,
+            similarityService);
     }
 
     [Fact]
@@ -121,37 +125,6 @@ public class MemoryServiceTests : IClassFixture<DatabaseFixture>
         var pattern = db.Patterns.FirstOrDefault(p => p.Symptom == uniqueTrigger);
         Assert.NotNull(pattern);
         Assert.Equal("applied fix", pattern.Resolution);
-    }
-
-    [Fact]
-    public async Task SearchPastIncidents_FindsSimilarIssues()
-    {
-        // Arrange
-        var threadId1 = (ulong)Random.Shared.NextInt64();
-        var threadId2 = (ulong)Random.Shared.NextInt64();
-
-        var inv1 = await _service.StartInvestigationAsync(threadId1, "container crashed nginx");
-        await _service.ResolveInvestigationAsync(inv1.Id, "restarted container");
-
-        var inv2 = await _service.StartInvestigationAsync(threadId2, "container stopped nginx");
-        await _service.ResolveInvestigationAsync(inv2.Id, "out of memory");
-
-        // Act
-        var results = await _service.SearchPastIncidentsAsync("nginx container");
-
-        // Assert
-        Assert.NotEmpty(results);
-        Assert.Contains(results, r => r.Trigger.Contains("nginx"));
-    }
-
-    [Fact]
-    public async Task SearchPastIncidents_ReturnsEmptyForNoMatch()
-    {
-        // Act
-        var results = await _service.SearchPastIncidentsAsync("xyznonexistent123");
-
-        // Assert
-        Assert.Empty(results);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- **PrometheusQueryService**: Unified Prometheus API client replacing 4 independent implementations across PrometheusPlugin, MikroTikPlugin, SummaryDataAggregator, and AnomalyDetectionService
- **KeywordMatcher**: Static utility replacing 5 duplicate split-lowercase-score keyword matching implementations
- **Unified Prometheus DTOs** in `Models/Prometheus/` replacing 3 sets of private nested classes
- **Structured plugin data**: `MikroTikPlugin.GetRouterMetricsAsync()` and `TrueNASPlugin.GetPoolInfoAsync()` internal methods for type-safe data access by SummaryDataAggregator and AnomalyDetectionService
- **Delete `MemoryService.SearchPastIncidentsAsync`**: strict subset of `IncidentSimilarityService.FindSimilarAsync`, callers updated

Net reduction: ~400 lines. All 136 tests pass.

## Test plan
- [x] `dotnet build` succeeds
- [x] `dotnet test` — all 136 tests pass
- [ ] Verify Prometheus queries still work in production
- [ ] Verify `/api/investigations/search` endpoint returns correct data
- [ ] Verify anomaly detection background service operates normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)