### PR TITLE
Remove MCP pass-through layer, register plugins as MCP tools directly

### DIFF
--- a/src/HomelabBot/Mcp/HomelabMcpTools.cs
+++ b/src/HomelabBot/Mcp/HomelabMcpTools.cs
@@ -1,6 +1,5 @@
 using System.ComponentModel;
 using HomelabBot.Models;
-using HomelabBot.Plugins;
 using HomelabBot.Services;
 using ModelContextProtocol.Server;
 
@@ -9,109 +8,22 @@ namespace HomelabBot.Mcp;
 [McpServerToolType]
 public sealed class HomelabMcpTools
 {
-    private readonly DockerPlugin _docker;
-    private readonly PrometheusPlugin _prometheus;
-    private readonly AlertmanagerPlugin _alertmanager;
-    private readonly TrueNASPlugin _truenas;
-    private readonly MikroTikPlugin _mikrotik;
-    private readonly KnowledgePlugin _knowledge;
-    private readonly LokiPlugin _loki;
-    private readonly GrafanaPlugin _grafana;
-    private readonly HomeAssistantPlugin _homeAssistant;
-    private readonly NtfyPlugin _ntfy;
-    private readonly RunbookPlugin _runbook;
-    private readonly InvestigationPlugin _investigation;
     private readonly MemoryService _memoryService;
     private readonly HealthScoreService _healthScore;
     private readonly SummaryDataAggregator _summaryAggregator;
     private readonly ConversationService _conversationService;
 
     public HomelabMcpTools(
-        DockerPlugin docker,
-        PrometheusPlugin prometheus,
-        AlertmanagerPlugin alertmanager,
-        TrueNASPlugin truenas,
-        MikroTikPlugin mikrotik,
-        KnowledgePlugin knowledge,
-        LokiPlugin loki,
-        GrafanaPlugin grafana,
-        HomeAssistantPlugin homeAssistant,
-        NtfyPlugin ntfy,
-        RunbookPlugin runbook,
-        InvestigationPlugin investigation,
         MemoryService memoryService,
         HealthScoreService healthScore,
         SummaryDataAggregator summaryAggregator,
         ConversationService conversationService)
     {
-        _docker = docker;
-        _prometheus = prometheus;
-        _alertmanager = alertmanager;
-        _truenas = truenas;
-        _mikrotik = mikrotik;
-        _knowledge = knowledge;
-        _loki = loki;
-        _grafana = grafana;
-        _homeAssistant = homeAssistant;
-        _ntfy = ntfy;
-        _runbook = runbook;
-        _investigation = investigation;
         _memoryService = memoryService;
         _healthScore = healthScore;
         _summaryAggregator = summaryAggregator;
         _conversationService = conversationService;
     }
-
-    [McpServerTool]
-    [Description("List all Docker containers with their status")]
-    public Task<string> ListContainers() => _docker.ListContainers();
-
-    [McpServerTool]
-    [Description("Get detailed status for a specific container")]
-    public Task<string> GetContainerStatus(string containerName) => _docker.GetContainerStatus(containerName);
-
-    [McpServerTool]
-    [Description("Get recent logs from a container via Loki (time-based)")]
-    public Task<string> GetContainerLogs(string containerName, string since = "1h") => _loki.GetContainerLogs(containerName, since);
-
-    [McpServerTool]
-    [Description("Execute a PromQL query against Prometheus")]
-    public Task<string> QueryPrometheus(string query) => _prometheus.QueryPrometheus(query);
-
-    [McpServerTool]
-    [Description("Get CPU, memory, disk stats for the node")]
-    public Task<string> GetNodeStats() => _prometheus.GetNodeStats();
-
-    [McpServerTool]
-    [Description("Get currently firing alerts from Alertmanager")]
-    public Task<string> GetAlerts() => _alertmanager.GetActiveAlerts();
-
-    [McpServerTool]
-    [Description("Get ZFS pool health status from TrueNAS")]
-    public Task<string> GetPoolStatus() => _truenas.GetPoolStatus();
-
-    [McpServerTool]
-    [Description("Get MikroTik router status including CPU, memory, temperature")]
-    public Task<string> GetRouterStatus() => _mikrotik.GetRouterStatus();
-
-    [McpServerTool]
-    [Description("Search stored knowledge about the homelab")]
-    public Task<string> SearchKnowledge(string query) => _knowledge.RecallKnowledge(query);
-
-    [McpServerTool]
-    [Description("Search logs across all containers, optionally filtered by container name")]
-    public Task<string> SearchLogs(string searchText, string since = "1h", string? containerName = null)
-        => _loki.SearchLogs(searchText, since, containerName);
-
-    [McpServerTool]
-    [Description("Count error log lines per container, optionally filtered to a specific container")]
-    public Task<string> CountErrors(string since = "1h", string? containerName = null)
-        => _loki.CountErrorsByContainer(since, containerName);
-
-    [McpServerTool]
-    [Description("Execute a raw LogQL query against Loki")]
-    public Task<string> QueryLoki(string query, int limit = 100)
-        => _loki.QueryLogs(query, limit);
 
     [McpServerTool]
     [Description("Get current health score with breakdown")]
@@ -134,35 +46,6 @@ public sealed class HomelabMcpTools
 
         return ConversationSearchResult.FormatResults(results);
     }
-
-    [McpServerTool]
-    [Description("List all available Grafana dashboards")]
-    public Task<string> ListGrafanaDashboards() => _grafana.ListDashboards();
-
-    [McpServerTool]
-    [Description("Get the current state of a Home Assistant entity")]
-    public Task<string> GetEntityState(string entityId) => _homeAssistant.GetEntityState(entityId);
-
-    [McpServerTool]
-    [Description("Turn on a Home Assistant entity (light, switch, etc.)")]
-    public Task<string> TurnOn(string entityId) => _homeAssistant.TurnOn(entityId);
-
-    [McpServerTool]
-    [Description("Turn off a Home Assistant entity (light, switch, etc.)")]
-    public Task<string> TurnOff(string entityId) => _homeAssistant.TurnOff(entityId);
-
-    [McpServerTool]
-    [Description("Send a push notification via ntfy")]
-    public Task<string> SendNotification(string message, string? topic = null, string? title = null, int priority = 3)
-        => _ntfy.SendNotification(message, topic, title, priority);
-
-    [McpServerTool]
-    [Description("List all runbooks with their status and trigger conditions")]
-    public Task<string> ListRunbooks() => _runbook.ListRunbooks();
-
-    [McpServerTool]
-    [Description("Search past incidents for similar issues")]
-    public Task<string> SearchPastIncidents(string symptom) => _investigation.SearchPastIncidents(symptom);
 
     [McpServerTool]
     [Description("List all remediation patterns with their success rates")]

--- a/src/HomelabBot/Plugins/AlertmanagerPlugin.cs
+++ b/src/HomelabBot/Plugins/AlertmanagerPlugin.cs
@@ -5,9 +5,11 @@ using System.Text.Json.Serialization;
 using HomelabBot.Configuration;
 using Microsoft.Extensions.Options;
 using Microsoft.SemanticKernel;
+using ModelContextProtocol.Server;
 
 namespace HomelabBot.Plugins;
 
+[McpServerToolType]
 public sealed class AlertmanagerPlugin
 {
     private readonly HttpClient _httpClient;
@@ -25,6 +27,7 @@ public sealed class AlertmanagerPlugin
     }
 
     [KernelFunction]
+    [McpServerTool(Name = "GetAlerts")]
     [Description("Gets all currently firing alerts from Alertmanager.")]
     public async Task<string> GetActiveAlerts()
     {

--- a/src/HomelabBot/Plugins/DockerPlugin.cs
+++ b/src/HomelabBot/Plugins/DockerPlugin.cs
@@ -4,9 +4,11 @@ using Docker.DotNet;
 using Docker.DotNet.Models;
 using HomelabBot.Models;
 using Microsoft.SemanticKernel;
+using ModelContextProtocol.Server;
 
 namespace HomelabBot.Plugins;
 
+[McpServerToolType]
 public class DockerPlugin
 {
     private readonly DockerClient _client;
@@ -20,6 +22,7 @@ public class DockerPlugin
     }
 
     [KernelFunction]
+    [McpServerTool]
     [Description("Lists all Docker containers with their status. Returns container name, status, and image.")]
     public async Task<string> ListContainers()
     {
@@ -62,6 +65,7 @@ public class DockerPlugin
     }
 
     [KernelFunction]
+    [McpServerTool]
     [Description("Gets detailed status information for a specific container by name or ID.")]
     public virtual async Task<string> GetContainerStatus([Description("Container name or ID")] string containerName)
     {

--- a/src/HomelabBot/Plugins/GrafanaPlugin.cs
+++ b/src/HomelabBot/Plugins/GrafanaPlugin.cs
@@ -6,9 +6,11 @@ using HomelabBot.Configuration;
 using HomelabBot.Services;
 using Microsoft.Extensions.Options;
 using Microsoft.SemanticKernel;
+using ModelContextProtocol.Server;
 
 namespace HomelabBot.Plugins;
 
+[McpServerToolType]
 public sealed class GrafanaPlugin
 {
     private readonly HttpClient _httpClient;
@@ -35,6 +37,7 @@ public sealed class GrafanaPlugin
     }
 
     [KernelFunction]
+    [McpServerTool(Name = "ListGrafanaDashboards")]
     [Description("Lists all available Grafana dashboards with their UIDs and titles.")]
     public async Task<string> ListDashboards()
     {

--- a/src/HomelabBot/Plugins/HomeAssistantPlugin.cs
+++ b/src/HomelabBot/Plugins/HomeAssistantPlugin.cs
@@ -7,9 +7,11 @@ using System.Text.Json.Serialization;
 using HomelabBot.Configuration;
 using Microsoft.Extensions.Options;
 using Microsoft.SemanticKernel;
+using ModelContextProtocol.Server;
 
 namespace HomelabBot.Plugins;
 
+[McpServerToolType]
 public sealed class HomeAssistantPlugin
 {
     private readonly HttpClient _httpClient;
@@ -33,6 +35,7 @@ public sealed class HomeAssistantPlugin
     }
 
     [KernelFunction]
+    [McpServerTool]
     [Description("Gets the current state of a Home Assistant entity by its entity_id.")]
     public async Task<string> GetEntityState([Description("Entity ID (e.g., sensor.temperature, light.living_room)")] string entityId)
     {
@@ -157,6 +160,7 @@ public sealed class HomeAssistantPlugin
     }
 
     [KernelFunction]
+    [McpServerTool]
     [Description("Turns on a Home Assistant entity (light, switch, etc.).")]
     public async Task<string> TurnOn([Description("Entity ID to turn on")] string entityId)
     {
@@ -182,6 +186,7 @@ public sealed class HomeAssistantPlugin
     }
 
     [KernelFunction]
+    [McpServerTool]
     [Description("Turns off a Home Assistant entity (light, switch, etc.).")]
     public async Task<string> TurnOff([Description("Entity ID to turn off")] string entityId)
     {

--- a/src/HomelabBot/Plugins/InvestigationPlugin.cs
+++ b/src/HomelabBot/Plugins/InvestigationPlugin.cs
@@ -3,9 +3,11 @@ using System.Text;
 using HomelabBot.Models;
 using HomelabBot.Services;
 using Microsoft.SemanticKernel;
+using ModelContextProtocol.Server;
 
 namespace HomelabBot.Plugins;
 
+[McpServerToolType]
 public sealed class InvestigationPlugin
 {
     private readonly MemoryService _memoryService;
@@ -175,6 +177,7 @@ public sealed class InvestigationPlugin
     }
 
     [KernelFunction]
+    [McpServerTool]
     [Description("Search past incidents for similar issues. Use this to check history before starting a new investigation.")]
     public async Task<string> SearchPastIncidents(
         [Description("Symptom or keywords to search for")] string symptom)

--- a/src/HomelabBot/Plugins/KnowledgePlugin.cs
+++ b/src/HomelabBot/Plugins/KnowledgePlugin.cs
@@ -3,9 +3,11 @@ using System.Text;
 using HomelabBot.Services;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.ChatCompletion;
+using ModelContextProtocol.Server;
 
 namespace HomelabBot.Plugins;
 
+[McpServerToolType]
 public sealed class KnowledgePlugin
 {
     private readonly KnowledgeService _knowledgeService;
@@ -31,6 +33,7 @@ public sealed class KnowledgePlugin
     }
 
     [KernelFunction]
+    [McpServerTool(Name = "SearchKnowledge")]
     [Description("Recall what you know about a topic. Call this BEFORE taking actions to check existing knowledge.")]
     public async Task<string> RecallKnowledge(
         [Description("Topic to recall (e.g., 'docker', 'loki', 'network', 'alias'). Leave empty for all.")] string? topic = null)

--- a/src/HomelabBot/Plugins/LokiPlugin.cs
+++ b/src/HomelabBot/Plugins/LokiPlugin.cs
@@ -5,9 +5,11 @@ using System.Text.Json;
 using HomelabBot.Configuration;
 using Microsoft.Extensions.Options;
 using Microsoft.SemanticKernel;
+using ModelContextProtocol.Server;
 
 namespace HomelabBot.Plugins;
 
+[McpServerToolType]
 public sealed class LokiPlugin
 {
     private readonly HttpClient _httpClient;
@@ -102,6 +104,7 @@ public sealed class LokiPlugin
     }
 
     [KernelFunction]
+    [McpServerTool(Name = "QueryLoki")]
     [Description("Executes a LogQL query against Loki. Returns matching log entries. Use ListLabels first to discover available labels.")]
     public async Task<string> QueryLogs(
         [Description("LogQL query expression (e.g., '{compose_service=\"traefik\"}' or '{container_name=~\".*traefik.*\"}')")] string query,
@@ -179,6 +182,7 @@ public sealed class LokiPlugin
     }
 
     [KernelFunction]
+    [McpServerTool]
     [Description("Gets recent logs for a specific Docker container. Tries multiple label patterns to find logs.")]
     public async Task<string> GetContainerLogs(
         [Description("Container name (will try multiple label patterns like compose_service, container_name)")] string containerName,
@@ -321,6 +325,7 @@ public sealed class LokiPlugin
     }
 
     [KernelFunction]
+    [McpServerTool(Name = "CountErrors")]
     [Description("Counts error/exception log lines per container over a time window. Returns container name and error count.")]
     public async Task<string> CountErrorsByContainer(
         [Description("Time range like '1h', '6h', '24h' (default 1h)")] string since = "1h",
@@ -438,6 +443,7 @@ public sealed class LokiPlugin
     }
 
     [KernelFunction]
+    [McpServerTool]
     [Description("Searches all logs for specific text (grep-style search).")]
     public async Task<string> SearchLogs(
         [Description("Text to search for in logs")] string searchText,

--- a/src/HomelabBot/Plugins/MikroTikPlugin.cs
+++ b/src/HomelabBot/Plugins/MikroTikPlugin.cs
@@ -5,9 +5,11 @@ using HomelabBot.Models.Prometheus;
 using HomelabBot.Services;
 using Microsoft.Extensions.Options;
 using Microsoft.SemanticKernel;
+using ModelContextProtocol.Server;
 
 namespace HomelabBot.Plugins;
 
+[McpServerToolType]
 public sealed class MikroTikPlugin
 {
     private readonly PrometheusQueryService _prometheus;
@@ -25,6 +27,7 @@ public sealed class MikroTikPlugin
     }
 
     [KernelFunction]
+    [McpServerTool]
     [Description("Gets the current status of the MikroTik router including uptime, CPU, memory usage, and temperature.")]
     public async Task<string> GetRouterStatus()
     {

--- a/src/HomelabBot/Plugins/NtfyPlugin.cs
+++ b/src/HomelabBot/Plugins/NtfyPlugin.cs
@@ -4,9 +4,11 @@ using System.Text;
 using HomelabBot.Configuration;
 using Microsoft.Extensions.Options;
 using Microsoft.SemanticKernel;
+using ModelContextProtocol.Server;
 
 namespace HomelabBot.Plugins;
 
+[McpServerToolType]
 public sealed class NtfyPlugin
 {
     private readonly HttpClient _httpClient;
@@ -26,6 +28,7 @@ public sealed class NtfyPlugin
     }
 
     [KernelFunction]
+    [McpServerTool]
     [Description("Sends a push notification via ntfy. Can specify topic, title, and priority.")]
     public async Task<string> SendNotification(
         [Description("The notification message content")] string message,

--- a/src/HomelabBot/Plugins/PrometheusPlugin.cs
+++ b/src/HomelabBot/Plugins/PrometheusPlugin.cs
@@ -3,9 +3,11 @@ using System.Text;
 using HomelabBot.Models.Prometheus;
 using HomelabBot.Services;
 using Microsoft.SemanticKernel;
+using ModelContextProtocol.Server;
 
 namespace HomelabBot.Plugins;
 
+[McpServerToolType]
 public sealed class PrometheusPlugin
 {
     private readonly PrometheusQueryService _prometheus;
@@ -82,6 +84,7 @@ public sealed class PrometheusPlugin
     }
 
     [KernelFunction]
+    [McpServerTool]
     [Description("Executes a PromQL query against Prometheus. Returns the current value of the expression.")]
     public async Task<string> QueryPrometheus([Description("PromQL query expression")] string query)
     {
@@ -122,6 +125,7 @@ public sealed class PrometheusPlugin
     }
 
     [KernelFunction]
+    [McpServerTool]
     [Description("Gets current CPU, memory, and disk usage for the node (Ubuntu VM).")]
     public async Task<string> GetNodeStats()
     {

--- a/src/HomelabBot/Plugins/RunbookPlugin.cs
+++ b/src/HomelabBot/Plugins/RunbookPlugin.cs
@@ -6,9 +6,11 @@ using HomelabBot.Data.Entities;
 using HomelabBot.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.SemanticKernel;
+using ModelContextProtocol.Server;
 
 namespace HomelabBot.Plugins;
 
+[McpServerToolType]
 public sealed class RunbookPlugin
 {
     private readonly IDbContextFactory<HomelabDbContext> _dbFactory;
@@ -62,6 +64,7 @@ public sealed class RunbookPlugin
     }
 
     [KernelFunction]
+    [McpServerTool]
     [Description("List all runbooks with their status, trigger conditions, and execution stats.")]
     public async Task<string> ListRunbooks()
     {

--- a/src/HomelabBot/Plugins/TrueNASPlugin.cs
+++ b/src/HomelabBot/Plugins/TrueNASPlugin.cs
@@ -6,9 +6,11 @@ using HomelabBot.Configuration;
 using HomelabBot.Models;
 using Microsoft.Extensions.Options;
 using Microsoft.SemanticKernel;
+using ModelContextProtocol.Server;
 
 namespace HomelabBot.Plugins;
 
+[McpServerToolType]
 public sealed class TrueNASPlugin
 {
     private readonly HttpClient _httpClient;
@@ -32,6 +34,7 @@ public sealed class TrueNASPlugin
     }
 
     [KernelFunction]
+    [McpServerTool]
     [Description("Gets the health status of all ZFS pools on TrueNAS.")]
     public async Task<string> GetPoolStatus()
     {

--- a/src/HomelabBot/Program.cs
+++ b/src/HomelabBot/Program.cs
@@ -102,6 +102,18 @@ try
     {
         builder.Services.AddMcpServer()
             .WithHttpTransport()
+            .WithTools<DockerPlugin>()
+            .WithTools<PrometheusPlugin>()
+            .WithTools<AlertmanagerPlugin>()
+            .WithTools<LokiPlugin>()
+            .WithTools<GrafanaPlugin>()
+            .WithTools<MikroTikPlugin>()
+            .WithTools<TrueNASPlugin>()
+            .WithTools<HomeAssistantPlugin>()
+            .WithTools<NtfyPlugin>()
+            .WithTools<KnowledgePlugin>()
+            .WithTools<InvestigationPlugin>()
+            .WithTools<RunbookPlugin>()
             .WithTools<HomelabMcpTools>();
     }
 


### PR DESCRIPTION
## Summary
- **Eliminate 15 one-line pass-through methods** in `HomelabMcpTools.cs` by moving `[McpServerTool]` attributes directly onto plugin `[KernelFunction]` methods
- **Register each plugin** with `.WithTools<T>()` in `Program.cs` (12 plugins + HomelabMcpTools for composite methods)
- **Preserve backwards-compatible MCP tool names** where plugin method names differ from old wrapper names (`GetAlerts`, `SearchKnowledge`, `CountErrors`, `QueryLoki`, `ListGrafanaDashboards`)
- **Retain 4 methods with actual logic** in HomelabMcpTools: `GetHealthScore`, `SearchConversations`, `ListPatterns`, `DeletePattern`

Net: -62 lines. All 136 tests pass.

## Test plan
- [x] `dotnet build` succeeds
- [x] `dotnet test` — all 136 tests pass
- [ ] Verify MCP tools are discoverable via MCP client
- [ ] Verify tool names match previous names (no client breakage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)