### PR TITLE
Miscellaneous cleanup: renames, dead code removal, dedup

### DIFF
--- a/src/HomelabBot/Commands/HomeLabCommands.cs
+++ b/src/HomelabBot/Commands/HomeLabCommands.cs
@@ -146,7 +146,7 @@ public class HomeLabCommands : ApplicationCommandModule
             _logger.LogDebug("Logs command invoked for {Container} by {User}",
                 containerName, ctx.User.Username);
 
-            var logs = await _dockerPlugin.GetContainerLogs(containerName, (int)lines);
+            var logs = await _dockerPlugin.GetContainerLogsFromDocker(containerName, (int)lines);
 
             await EditResponseWithContentOrSplitAsync(ctx, logs,
                 $"Logs for **{containerName}** (last {lines} lines):");
@@ -393,7 +393,7 @@ public class HomeLabCommands : ApplicationCommandModule
             if (!string.IsNullOrWhiteSpace(container))
             {
                 var errors = await _lokiPlugin.CountErrorsByContainer("1h");
-                var logs = await _lokiPlugin.GetContainerLogs(container, "1h");
+                var logs = await _lokiPlugin.GetContainerLogsFromLoki(container, "1h");
 
                 // Truncate for token efficiency
                 if (logs.Length > 2000)

--- a/src/HomelabBot/Configuration/BotConfiguration.cs
+++ b/src/HomelabBot/Configuration/BotConfiguration.cs
@@ -37,14 +37,6 @@ public sealed class BotConfiguration
 public sealed class MikroTikConfiguration
 {
     public const string SectionName = "MikroTik";
-
-    public required string Host { get; init; }
-
-    public int ApiPort { get; init; } = 8728;
-
-    public required string Username { get; init; }
-
-    public required string Password { get; init; }
 }
 
 public sealed class TrueNASConfiguration

--- a/src/HomelabBot/Controllers/ConversationsController.cs
+++ b/src/HomelabBot/Controllers/ConversationsController.cs
@@ -1,4 +1,5 @@
 using HomelabBot.Data;
+using HomelabBot.Models;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 
@@ -87,15 +88,6 @@ public class ConversationsController : ControllerBase
         });
     }
 }
-
-public record PagedResult<T>
-{
-    public required IReadOnlyList<T> Items { get; init; }
-    public int TotalCount { get; init; }
-    public int Page { get; init; }
-    public int PageSize { get; init; }
-}
-
 public record ConversationDto
 {
     public int Id { get; init; }

--- a/src/HomelabBot/Controllers/InvestigationsController.cs
+++ b/src/HomelabBot/Controllers/InvestigationsController.cs
@@ -1,3 +1,4 @@
+using HomelabBot.Models;
 using HomelabBot.Services;
 using Microsoft.AspNetCore.Mvc;
 

--- a/src/HomelabBot/Controllers/TelemetryController.cs
+++ b/src/HomelabBot/Controllers/TelemetryController.cs
@@ -1,4 +1,5 @@
 using HomelabBot.Data;
+using HomelabBot.Models;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 

--- a/src/HomelabBot/Models/PagedResult.cs
+++ b/src/HomelabBot/Models/PagedResult.cs
@@ -1,0 +1,9 @@
+namespace HomelabBot.Models;
+
+public record PagedResult<T>
+{
+    public required IReadOnlyList<T> Items { get; init; }
+    public int TotalCount { get; init; }
+    public int Page { get; init; }
+    public int PageSize { get; init; }
+}

--- a/src/HomelabBot/Plugins/DockerPlugin.cs
+++ b/src/HomelabBot/Plugins/DockerPlugin.cs
@@ -217,8 +217,8 @@ public class DockerPlugin
     }
 
     [KernelFunction]
-    [Description("Gets the recent logs from a container. Returns the last N lines of logs.")]
-    public async Task<string> GetContainerLogs(
+    [Description("Gets the recent logs from a Docker container via the Docker API. Returns the last N lines of logs.")]
+    public async Task<string> GetContainerLogsFromDocker(
         [Description("Container name or ID")] string containerName,
         [Description("Number of lines to retrieve (default 50)")] int lines = 50)
     {

--- a/src/HomelabBot/Plugins/KnowledgePlugin.cs
+++ b/src/HomelabBot/Plugins/KnowledgePlugin.cs
@@ -49,26 +49,7 @@ public sealed class KnowledgePlugin
                 : "I don't have any knowledge stored yet. Use /discover to learn about the homelab.";
         }
 
-        var sb = new StringBuilder();
-        sb.AppendLine($"**What I know about {topic ?? "the homelab"}:**\n");
-
-        var byTopic = facts.GroupBy(f => f.Topic);
-        foreach (var group in byTopic)
-        {
-            sb.AppendLine($"**{group.Key}**");
-            foreach (var fact in group)
-            {
-                var stale = fact.LastVerified.HasValue &&
-                    (DateTime.UtcNow - fact.LastVerified.Value).TotalDays > 30;
-                var confidence = fact.Confidence < 0.5 ? " (uncertain)" : "";
-                var warning = stale ? " ⚠️" : "";
-                sb.AppendLine($"- {fact.Fact}{confidence}{warning}");
-            }
-
-            sb.AppendLine();
-        }
-
-        return sb.ToString();
+        return FormatKnowledgeFacts(facts, $"What I know about {topic ?? "the homelab"}");
     }
 
     [KernelFunction]
@@ -87,26 +68,7 @@ public sealed class KnowledgePlugin
             return $"No relevant knowledge found for: {query}";
         }
 
-        var sb = new StringBuilder();
-        sb.AppendLine($"**Relevant knowledge for \"{query}\":**\n");
-
-        var byTopic = facts.GroupBy(f => f.Topic);
-        foreach (var group in byTopic)
-        {
-            sb.AppendLine($"**{group.Key}**");
-            foreach (var fact in group)
-            {
-                var stale = fact.LastVerified.HasValue &&
-                    (DateTime.UtcNow - fact.LastVerified.Value).TotalDays > 30;
-                var confidence = fact.Confidence < 0.5 ? " (uncertain)" : "";
-                var warning = stale ? " ⚠️" : "";
-                sb.AppendLine($"- {fact.Fact}{confidence}{warning}");
-            }
-
-            sb.AppendLine();
-        }
-
-        return sb.ToString();
+        return FormatKnowledgeFacts(facts, $"Relevant knowledge for \"{query}\"");
     }
 
     [KernelFunction]
@@ -166,5 +128,29 @@ public sealed class KnowledgePlugin
 
         await _knowledgeService.InvalidateAsync(topic, factContains);
         return $"Marked knowledge about '{factContains}' in {topic} as outdated.";
+    }
+
+    private static string FormatKnowledgeFacts(List<Data.Entities.Knowledge> facts, string heading)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"**{heading}:**\n");
+
+        var byTopic = facts.GroupBy(f => f.Topic);
+        foreach (var group in byTopic)
+        {
+            sb.AppendLine($"**{group.Key}**");
+            foreach (var fact in group)
+            {
+                var stale = fact.LastVerified.HasValue &&
+                    (DateTime.UtcNow - fact.LastVerified.Value).TotalDays > 30;
+                var confidence = fact.Confidence < 0.5 ? " (uncertain)" : "";
+                var warning = stale ? " ⚠️" : "";
+                sb.AppendLine($"- {fact.Fact}{confidence}{warning}");
+            }
+
+            sb.AppendLine();
+        }
+
+        return sb.ToString();
     }
 }

--- a/src/HomelabBot/Plugins/LokiPlugin.cs
+++ b/src/HomelabBot/Plugins/LokiPlugin.cs
@@ -183,9 +183,9 @@ public sealed class LokiPlugin
     }
 
     [KernelFunction]
-    [McpServerTool]
-    [Description("Gets recent logs for a specific Docker container. Tries multiple label patterns to find logs.")]
-    public async Task<string> GetContainerLogs(
+    [McpServerTool(Name = "GetContainerLogs")]
+    [Description("Gets recent logs for a specific Docker container from Loki. Tries multiple label patterns to find logs.")]
+    public async Task<string> GetContainerLogsFromLoki(
         [Description("Container name (will try multiple label patterns like compose_service, container_name)")] string containerName,
         [Description("Time range like '1h', '30m', '15m' (default 1h)")] string since = "1h")
     {

--- a/src/HomelabBot/Services/HealingChainService.cs
+++ b/src/HomelabBot/Services/HealingChainService.cs
@@ -118,7 +118,7 @@ public sealed class HealingChainService
             Issue: {symptom}{containerContext}{pastSection}
 
             Available plugins and functions:
-            - Docker: ListContainers, GetContainerStatus(containerName), GetContainerLogs(containerName, tail), RestartContainer(containerName), StartContainer(containerName), StopContainer(containerName)
+            - Docker: ListContainers, GetContainerStatus(containerName), GetContainerLogsFromDocker(containerName, tail), RestartContainer(containerName), StartContainer(containerName), StopContainer(containerName)
             - Prometheus: GetNodeStats, GetTargets
             - Loki: SearchLogs(query, since), CountErrorsByContainer(since)
             - TrueNAS: GetPoolStatus, GetDatasetUsage


### PR DESCRIPTION
## Summary
- **Rename GetContainerLogs** to `GetContainerLogsFromDocker` (DockerPlugin) and `GetContainerLogsFromLoki` (LokiPlugin) to disambiguate log sources. MCP backwards-compatible via `[McpServerTool(Name = "GetContainerLogs")]`
- **Move `PagedResult<T>`** from `ConversationsController.cs` to `Models/PagedResult.cs` for proper shared model placement
- **Remove dead `MikroTikConfiguration` fields** (`Host`, `ApiPort`, `Username`, `Password`) — plugin only queries via Prometheus
- **Extract `FormatKnowledgeFacts`** in KnowledgePlugin, eliminating duplicate formatting between `RecallKnowledge` and `SmartRecallKnowledge`

Net: -19 lines. All 136 tests pass.

## Test plan
- [x] `dotnet build` succeeds
- [x] `dotnet test` — all 136 tests pass
- [ ] Verify `/containers` slash command still works
- [ ] Verify MCP `GetContainerLogs` tool still resolves
- [ ] Verify MikroTik config section loads without removed fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)