### PR TITLE
Extract ScheduleHelper, fix similarity double-call, DockerPlugin DI, remove /status

### DIFF
--- a/src/HomelabBot/Commands/HomeLabCommands.cs
+++ b/src/HomelabBot/Commands/HomeLabCommands.cs
@@ -46,34 +46,6 @@ public class HomeLabCommands : ApplicationCommandModule
         _logger = logger;
     }
 
-    [SlashCommand("status", "Get a quick overview of system status")]
-    public async Task StatusCommand(InteractionContext ctx)
-    {
-        await ctx.DeferAsync();
-
-        try
-        {
-            _logger.LogDebug("Status command invoked by {User}", ctx.User.Username);
-
-            var containers = await _dockerPlugin.ListContainers();
-
-            var embed = new DiscordEmbedBuilder()
-                .WithTitle("System Status")
-                .WithDescription(containers)
-                .WithColor(DiscordColor.Green)
-                .WithTimestamp(DateTimeOffset.UtcNow)
-                .Build();
-
-            await ctx.EditResponseAsync(new DiscordWebhookBuilder().AddEmbed(embed));
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "Error in status command");
-            await ctx.EditResponseAsync(new DiscordWebhookBuilder()
-                .WithContent($"Error getting status: {ex.Message}"));
-        }
-    }
-
     [SlashCommand("containers", "List all Docker containers")]
     public async Task ContainersCommand(InteractionContext ctx)
     {

--- a/src/HomelabBot/Plugins/DockerPlugin.cs
+++ b/src/HomelabBot/Plugins/DockerPlugin.cs
@@ -14,11 +14,10 @@ public class DockerPlugin
     private readonly DockerClient _client;
     private readonly ILogger<DockerPlugin> _logger;
 
-    public DockerPlugin(ILogger<DockerPlugin> logger)
+    public DockerPlugin(DockerClient client, ILogger<DockerPlugin> logger)
     {
+        _client = client;
         _logger = logger;
-        _client = new DockerClientConfiguration(new Uri("unix:///var/run/docker.sock"))
-            .CreateClient();
     }
 
     [KernelFunction]

--- a/src/HomelabBot/Program.cs
+++ b/src/HomelabBot/Program.cs
@@ -162,6 +162,8 @@ try
     builder.Services.AddSingleton<PrometheusQueryService>();
 
     // Plugins
+    builder.Services.AddSingleton<Docker.DotNet.DockerClient>(_ =>
+        new Docker.DotNet.DockerClientConfiguration(new Uri("unix:///var/run/docker.sock")).CreateClient());
     builder.Services.AddSingleton<DockerPlugin>();
     builder.Services.AddSingleton<PrometheusPlugin>();
     builder.Services.AddSingleton<AlertmanagerPlugin>();

--- a/src/HomelabBot/Services/AlertWebhookService.cs
+++ b/src/HomelabBot/Services/AlertWebhookService.cs
@@ -134,8 +134,14 @@ public sealed class AlertWebhookService
                 }
             }
 
+            // Check for similar past incidents (Deja Vu) — hoisted to share with healing chain
+            var similarIncidents = await _similarityService.FindSimilarAsync(
+                searchTerms, containerName, alert.Labels, limit: 3, ct: ct);
+            var dejaVuContext = IncidentSimilarityService.FormatDejaVuContext(similarIncidents);
+
             // Escalate to healing chain if simple remediation didn't handle it
-            var chainResult = await _healingChainService.PlanAndExecuteAsync(searchTerms, containerName, ct);
+            var chainResult = await _healingChainService.PlanAndExecuteAsync(
+                searchTerms, containerName, ct, similarIncidents);
             if (chainResult is { Success: true })
             {
                 if (warRoom != null)
@@ -148,11 +154,6 @@ public sealed class AlertWebhookService
                 await _discordService.SendDmAsync(HomelabOwner.DiscordUserId, chainEmbed);
                 return;
             }
-
-            // Check for similar past incidents (Deja Vu)
-            var similarIncidents = await _similarityService.FindSimilarAsync(
-                searchTerms, containerName, alert.Labels, limit: 3, ct: ct);
-            var dejaVuContext = IncidentSimilarityService.FormatDejaVuContext(similarIncidents);
 
             var patternContext = "";
             if (matchedPatterns.Count > 0)

--- a/src/HomelabBot/Services/DailySummaryService.cs
+++ b/src/HomelabBot/Services/DailySummaryService.cs
@@ -43,7 +43,7 @@ public sealed class DailySummaryService : BackgroundService
                     continue;
                 }
 
-                var delay = CalculateDelayUntilNextRun();
+                var delay = ScheduleHelper.CalculateDelayUntilNextRun(_config.CurrentValue.ScheduleTime, _config.CurrentValue.TimeZone);
                 _logger.LogInformation("Next daily healthcheck in {Delay}", delay);
 
                 await Task.Delay(delay, stoppingToken);
@@ -60,42 +60,6 @@ public sealed class DailySummaryService : BackgroundService
                 await Task.Delay(TimeSpan.FromMinutes(5), stoppingToken);
             }
         }
-    }
-
-    private TimeSpan CalculateDelayUntilNextRun()
-    {
-        var config = _config.CurrentValue;
-
-        if (!TimeOnly.TryParse(config.ScheduleTime, out var scheduleTime))
-        {
-            _logger.LogWarning("Invalid ScheduleTime '{Time}', defaulting to 08:00", config.ScheduleTime);
-            scheduleTime = new TimeOnly(8, 0);
-        }
-
-        TimeZoneInfo tz;
-        try
-        {
-            tz = TimeZoneInfo.FindSystemTimeZoneById(config.TimeZone);
-        }
-        catch
-        {
-            _logger.LogWarning("Invalid TimeZone '{TZ}', defaulting to UTC", config.TimeZone);
-            tz = TimeZoneInfo.Utc;
-        }
-
-        var nowUtc = DateTime.UtcNow;
-        var nowLocal = TimeZoneInfo.ConvertTimeFromUtc(nowUtc, tz);
-        var todaySchedule = nowLocal.Date + scheduleTime.ToTimeSpan();
-
-        var nextRun = nowLocal < todaySchedule ? todaySchedule : todaySchedule.AddDays(1);
-        if (tz.IsInvalidTime(nextRun))
-        {
-            nextRun = nextRun.AddHours(1);
-        }
-
-        var nextRunUtc = TimeZoneInfo.ConvertTimeToUtc(nextRun, tz);
-
-        return nextRunUtc - nowUtc;
     }
 
     private async Task RunHealthcheckCycleAsync(CancellationToken ct)

--- a/src/HomelabBot/Services/HealingChainService.cs
+++ b/src/HomelabBot/Services/HealingChainService.cs
@@ -40,7 +40,8 @@ public sealed class HealingChainService
     public async Task<HealingChainResult?> PlanAndExecuteAsync(
         string symptom,
         string? containerName,
-        CancellationToken ct)
+        CancellationToken ct,
+        List<SimilarIncident>? similarIncidents = null)
     {
         if (!_config.Enabled)
         {
@@ -53,7 +54,7 @@ public sealed class HealingChainService
             return null;
         }
 
-        var similarIncidents = await _similarityService.FindSimilarAsync(symptom, containerName, limit: 3, ct: ct);
+        similarIncidents ??= await _similarityService.FindSimilarAsync(symptom, containerName, limit: 3, ct: ct);
         var pastContext = similarIncidents.Count > 0
             ? IncidentSimilarityService.FormatDejaVuContext(similarIncidents)
             : "";

--- a/src/HomelabBot/Services/KnowledgeRefreshService.cs
+++ b/src/HomelabBot/Services/KnowledgeRefreshService.cs
@@ -46,7 +46,7 @@ public sealed class KnowledgeRefreshService : BackgroundService
                     continue;
                 }
 
-                var delay = CalculateDelayUntilNextRun();
+                var delay = ScheduleHelper.CalculateDelayUntilNextRun(_config.CurrentValue.ScheduleTime, _config.CurrentValue.TimeZone);
                 _logger.LogInformation("Next knowledge refresh in {Delay}", delay);
 
                 await Task.Delay(delay, stoppingToken);
@@ -63,42 +63,6 @@ public sealed class KnowledgeRefreshService : BackgroundService
                 await Task.Delay(TimeSpan.FromMinutes(5), stoppingToken);
             }
         }
-    }
-
-    private TimeSpan CalculateDelayUntilNextRun()
-    {
-        var config = _config.CurrentValue;
-
-        if (!TimeOnly.TryParse(config.ScheduleTime, out var scheduleTime))
-        {
-            _logger.LogWarning("Invalid ScheduleTime '{Time}', defaulting to 05:00", config.ScheduleTime);
-            scheduleTime = new TimeOnly(5, 0);
-        }
-
-        TimeZoneInfo tz;
-        try
-        {
-            tz = TimeZoneInfo.FindSystemTimeZoneById(config.TimeZone);
-        }
-        catch (Exception ex) when (ex is TimeZoneNotFoundException or InvalidTimeZoneException)
-        {
-            _logger.LogWarning(ex, "Invalid TimeZone '{TZ}', defaulting to UTC", config.TimeZone);
-            tz = TimeZoneInfo.Utc;
-        }
-
-        var nowUtc = DateTime.UtcNow;
-        var nowLocal = TimeZoneInfo.ConvertTimeFromUtc(nowUtc, tz);
-        var todaySchedule = nowLocal.Date + scheduleTime.ToTimeSpan();
-
-        var nextRun = nowLocal < todaySchedule ? todaySchedule : todaySchedule.AddDays(1);
-        if (tz.IsInvalidTime(nextRun))
-        {
-            nextRun = nextRun.AddHours(1);
-        }
-
-        var nextRunUtc = TimeZoneInfo.ConvertTimeToUtc(nextRun, tz);
-
-        return nextRunUtc - nowUtc;
     }
 
     private async Task RunRefreshAsync(CancellationToken ct)

--- a/src/HomelabBot/Services/ScheduleHelper.cs
+++ b/src/HomelabBot/Services/ScheduleHelper.cs
@@ -1,0 +1,62 @@
+namespace HomelabBot.Services;
+
+public static class ScheduleHelper
+{
+    public static TimeSpan CalculateDelayUntilNextRun(
+        string scheduleTime, string timeZone, DayOfWeek? scheduleDay = null)
+    {
+        TimeZoneInfo tz;
+        try
+        {
+            tz = TimeZoneInfo.FindSystemTimeZoneById(timeZone);
+        }
+        catch (TimeZoneNotFoundException)
+        {
+            tz = TimeZoneInfo.Utc;
+        }
+        catch (InvalidTimeZoneException)
+        {
+            tz = TimeZoneInfo.Utc;
+        }
+
+        if (!TimeOnly.TryParse(scheduleTime, out var parsedTime))
+        {
+            parsedTime = new TimeOnly(8, 0);
+        }
+
+        var nowUtc = DateTime.UtcNow;
+        var nowLocal = TimeZoneInfo.ConvertTimeFromUtc(nowUtc, tz);
+        var targetToday = nowLocal.Date + parsedTime.ToTimeSpan();
+
+        if (scheduleDay.HasValue)
+        {
+            // Weekly scheduling: find next occurrence of the target day
+            var daysUntil = ((int)scheduleDay.Value - (int)nowLocal.DayOfWeek + 7) % 7;
+            if (daysUntil == 0 && nowLocal >= targetToday)
+            {
+                daysUntil = 7;
+            }
+
+            targetToday = targetToday.AddDays(daysUntil);
+        }
+        else
+        {
+            // Daily scheduling: if past target, schedule for tomorrow
+            if (nowLocal >= targetToday)
+            {
+                targetToday = targetToday.AddDays(1);
+            }
+        }
+
+        // Handle DST invalid times
+        if (tz.IsInvalidTime(targetToday))
+        {
+            targetToday = targetToday.AddHours(1);
+        }
+
+        var targetUtc = TimeZoneInfo.ConvertTimeToUtc(targetToday, tz);
+        var delay = targetUtc - nowUtc;
+
+        return delay > TimeSpan.Zero ? delay : TimeSpan.FromMinutes(1);
+    }
+}

--- a/src/HomelabBot/Services/SecurityAuditService.cs
+++ b/src/HomelabBot/Services/SecurityAuditService.cs
@@ -42,7 +42,7 @@ public sealed class SecurityAuditService : BackgroundService
                     continue;
                 }
 
-                var delay = CalculateDelayUntilNextRun();
+                var delay = ScheduleHelper.CalculateDelayUntilNextRun(_config.CurrentValue.ScheduleTime, _config.CurrentValue.TimeZone, _config.CurrentValue.ScheduleDay);
                 _logger.LogInformation("Next security audit in {Delay}", delay);
 
                 await Task.Delay(delay, stoppingToken);
@@ -106,48 +106,5 @@ public sealed class SecurityAuditService : BackgroundService
         {
             _logger.LogError(ex, "Failed to generate security audit");
         }
-    }
-
-    private TimeSpan CalculateDelayUntilNextRun()
-    {
-        var config = _config.CurrentValue;
-
-        if (!TimeOnly.TryParse(config.ScheduleTime, out var scheduleTime))
-        {
-            _logger.LogWarning("Invalid ScheduleTime '{Time}', defaulting to 04:00", config.ScheduleTime);
-            scheduleTime = new TimeOnly(4, 0);
-        }
-
-        TimeZoneInfo tz;
-        try
-        {
-            tz = TimeZoneInfo.FindSystemTimeZoneById(config.TimeZone);
-        }
-        catch
-        {
-            _logger.LogWarning("Invalid TimeZone '{TZ}', defaulting to UTC", config.TimeZone);
-            tz = TimeZoneInfo.Utc;
-        }
-
-        var nowUtc = DateTime.UtcNow;
-        var nowLocal = TimeZoneInfo.ConvertTimeFromUtc(nowUtc, tz);
-
-        // Find next occurrence of the scheduled day + time
-        var daysUntilTarget = ((int)config.ScheduleDay - (int)nowLocal.DayOfWeek + 7) % 7;
-        var nextRun = nowLocal.Date.AddDays(daysUntilTarget) + scheduleTime.ToTimeSpan();
-
-        // If we're past the time today (and today is the target day), schedule for next week
-        if (nextRun <= nowLocal)
-        {
-            nextRun = nextRun.AddDays(7);
-        }
-
-        if (tz.IsInvalidTime(nextRun))
-        {
-            nextRun = nextRun.AddHours(1);
-        }
-
-        var nextRunUtc = TimeZoneInfo.ConvertTimeToUtc(nextRun, tz);
-        return nextRunUtc - nowUtc;
     }
 }

--- a/tests/HomelabBot.Tests/AutoRemediationServiceTests.cs
+++ b/tests/HomelabBot.Tests/AutoRemediationServiceTests.cs
@@ -1,3 +1,4 @@
+using Docker.DotNet;
 using HomelabBot.Configuration;
 using HomelabBot.Data.Entities;
 using HomelabBot.Models;
@@ -18,7 +19,8 @@ public class AutoRemediationServiceTests : IClassFixture<DatabaseFixture>, IDisp
     public AutoRemediationServiceTests(DatabaseFixture fixture)
     {
         _fixture = fixture;
-        _dockerPlugin = Substitute.For<DockerPlugin>(NullLogger<DockerPlugin>.Instance);
+        var dockerClient = new DockerClientConfiguration().CreateClient();
+        _dockerPlugin = Substitute.For<DockerPlugin>(dockerClient, NullLogger<DockerPlugin>.Instance);
         _stateStore = Substitute.For<ServiceStateStore>(_fixture.DbContextFactory);
 
         // LoadStateAsync calls GetAsync twice during construction


### PR DESCRIPTION
## Summary
- **ScheduleHelper**: Extract shared `CalculateDelayUntilNextRun(scheduleTime, timeZone, scheduleDay?)` replacing 3 private copies across DailySummaryService, KnowledgeRefreshService, SecurityAuditService (~105 lines removed)
- **Fix IncidentSimilarity double-call**: Hoist `FindSimilarAsync` in AlertWebhookService and pass results to `HealingChainService.PlanAndExecuteAsync` via new optional parameter, avoiding redundant DB query
- **Remove `/status` command**: Duplicate of `/containers` — identical implementation
- **DockerPlugin DI**: Inject `DockerClient` via DI instead of creating inline

Net reduction: ~76 lines. All 136 tests pass.

## Test plan
- [x] `dotnet build` succeeds
- [x] `dotnet test` — all 136 tests pass
- [ ] Verify daily summary, security audit, knowledge refresh still trigger at correct times
- [ ] Verify alert webhook flow still works end-to-end
- [ ] Verify `/containers` command works (after `/status` removal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)