### PR TITLE
Rename MemoryService → InvestigationService, remove dead WarRoom FKs, simplify FallbackChatCompletion

### DIFF
--- a/src/HomelabBot/Commands/HomeLabCommands.cs
+++ b/src/HomelabBot/Commands/HomeLabCommands.cs
@@ -17,7 +17,7 @@ public class HomeLabCommands : ApplicationCommandModule
     private readonly HealthScoreService _healthScoreService;
     private readonly SecurityAuditService _securityAuditService;
     private readonly AutoRemediationService _autoRemediationService;
-    private readonly MemoryService _memoryService;
+    private readonly InvestigationService _memoryService;
     private readonly ILogger<HomeLabCommands> _logger;
 
     public HomeLabCommands(
@@ -30,7 +30,7 @@ public class HomeLabCommands : ApplicationCommandModule
         HealthScoreService healthScoreService,
         SecurityAuditService securityAuditService,
         AutoRemediationService autoRemediationService,
-        MemoryService memoryService,
+        InvestigationService memoryService,
         ILogger<HomeLabCommands> logger)
     {
         _dockerPlugin = dockerPlugin;

--- a/src/HomelabBot/Controllers/InvestigationsController.cs
+++ b/src/HomelabBot/Controllers/InvestigationsController.cs
@@ -8,10 +8,10 @@ namespace HomelabBot.Controllers;
 [Route("api/[controller]")]
 public class InvestigationsController : ControllerBase
 {
-    private readonly MemoryService _memoryService;
+    private readonly InvestigationService _memoryService;
     private readonly IncidentSimilarityService _similarityService;
 
-    public InvestigationsController(MemoryService memoryService, IncidentSimilarityService similarityService)
+    public InvestigationsController(InvestigationService memoryService, IncidentSimilarityService similarityService)
     {
         _memoryService = memoryService;
         _similarityService = similarityService;

--- a/src/HomelabBot/Data/Entities/WarRoom.cs
+++ b/src/HomelabBot/Data/Entities/WarRoom.cs
@@ -14,10 +14,6 @@ public sealed class WarRoom
 
     public WarRoomStatus Status { get; set; } = WarRoomStatus.Active;
 
-    public int? InvestigationId { get; set; }
-
-    public int? HealingChainId { get; set; }
-
     public string TimelineJson { get; set; } = "[]";
 
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;

--- a/src/HomelabBot/Mcp/HomelabMcpTools.cs
+++ b/src/HomelabBot/Mcp/HomelabMcpTools.cs
@@ -8,13 +8,13 @@ namespace HomelabBot.Mcp;
 [McpServerToolType]
 public sealed class HomelabMcpTools
 {
-    private readonly MemoryService _memoryService;
+    private readonly InvestigationService _memoryService;
     private readonly HealthScoreService _healthScore;
     private readonly SummaryDataAggregator _summaryAggregator;
     private readonly ConversationService _conversationService;
 
     public HomelabMcpTools(
-        MemoryService memoryService,
+        InvestigationService memoryService,
         HealthScoreService healthScore,
         SummaryDataAggregator summaryAggregator,
         ConversationService conversationService)

--- a/src/HomelabBot/Plugins/InvestigationPlugin.cs
+++ b/src/HomelabBot/Plugins/InvestigationPlugin.cs
@@ -10,7 +10,7 @@ namespace HomelabBot.Plugins;
 [McpServerToolType]
 public sealed class InvestigationPlugin
 {
-    private readonly MemoryService _memoryService;
+    private readonly InvestigationService _memoryService;
     private readonly ConversationService _conversationService;
     private readonly IncidentSimilarityService _similarityService;
     private readonly ILogger<InvestigationPlugin> _logger;
@@ -19,7 +19,7 @@ public sealed class InvestigationPlugin
     private readonly Dictionary<ulong, int> _activeInvestigations = new();
 
     public InvestigationPlugin(
-        MemoryService memoryService,
+        InvestigationService memoryService,
         ConversationService conversationService,
         IncidentSimilarityService similarityService,
         ILogger<InvestigationPlugin> logger)

--- a/src/HomelabBot/Program.cs
+++ b/src/HomelabBot/Program.cs
@@ -181,7 +181,7 @@ try
     builder.Services.AddSingleton<IncidentSimilarityService>();
     builder.Services.AddSingleton<RunbookCompilerService>();
     builder.Services.AddSingleton<KnowledgeService>();
-    builder.Services.AddSingleton<MemoryService>();
+    builder.Services.AddSingleton<InvestigationService>();
     builder.Services.AddSingleton<UrlService>();
     builder.Services.AddSingleton<ConversationService>();
     builder.Services.AddSingleton<ConfirmationService>();

--- a/src/HomelabBot/Services/DiscordBotService.cs
+++ b/src/HomelabBot/Services/DiscordBotService.cs
@@ -16,7 +16,7 @@ public sealed class DiscordBotService : BackgroundService
     private readonly KernelService _kernelService;
     private readonly ConversationService _conversationService;
     private readonly ConfirmationService _confirmationService;
-    private readonly MemoryService _memoryService;
+    private readonly InvestigationService _memoryService;
     private readonly AutoRemediationService _autoRemediationService;
     private readonly IServiceProvider _serviceProvider;
     private readonly Lazy<SmartNotificationService> _smartNotification;
@@ -32,7 +32,7 @@ public sealed class DiscordBotService : BackgroundService
         KernelService kernelService,
         ConversationService conversationService,
         ConfirmationService confirmationService,
-        MemoryService memoryService,
+        InvestigationService memoryService,
         AutoRemediationService autoRemediationService,
         IServiceProvider serviceProvider)
     {

--- a/src/HomelabBot/Services/FallbackChatCompletionService.cs
+++ b/src/HomelabBot/Services/FallbackChatCompletionService.cs
@@ -1,7 +1,6 @@
 using System.Runtime.CompilerServices;
 using Microsoft.SemanticKernel;
 using Microsoft.SemanticKernel.ChatCompletion;
-using Microsoft.SemanticKernel.Connectors.OpenAI;
 
 namespace HomelabBot.Services;
 
@@ -47,29 +46,8 @@ public sealed class FallbackChatCompletionService : IChatCompletionService
         {
             _logger.LogWarning(ex, "Primary LLM failed, falling back to OpenRouter");
 
-            // Preserve caller's max_tokens, default temperature and enable tool calling
-            var maxTokens = 2048;
-            if (executionSettings?.ExtensionData?.TryGetValue("max_tokens", out var mt) == true)
-            {
-                if (mt is int i)
-                {
-                    maxTokens = i;
-                }
-                else if (mt is long l)
-                {
-                    maxTokens = (int)l;
-                }
-            }
-
-            var fallbackSettings = new OpenAIPromptExecutionSettings
-            {
-                Temperature = 0.7,
-                MaxTokens = maxTokens,
-                ToolCallBehavior = ToolCallBehavior.AutoInvokeKernelFunctions,
-            };
-
             return await _fallback.GetChatMessageContentsAsync(
-                chatHistory, fallbackSettings, kernel, cancellationToken);
+                chatHistory, executionSettings, kernel, cancellationToken);
         }
     }
 

--- a/src/HomelabBot/Services/InvestigationService.cs
+++ b/src/HomelabBot/Services/InvestigationService.cs
@@ -5,16 +5,16 @@ using Microsoft.EntityFrameworkCore;
 
 namespace HomelabBot.Services;
 
-public sealed class MemoryService
+public sealed class InvestigationService
 {
     private readonly IDbContextFactory<HomelabDbContext> _dbFactory;
-    private readonly ILogger<MemoryService> _logger;
+    private readonly ILogger<InvestigationService> _logger;
     private readonly RunbookCompilerService _runbookCompiler;
     private readonly IncidentSimilarityService _similarityService;
 
-    public MemoryService(
+    public InvestigationService(
         IDbContextFactory<HomelabDbContext> dbFactory,
-        ILogger<MemoryService> logger,
+        ILogger<InvestigationService> logger,
         RunbookCompilerService runbookCompiler,
         IncidentSimilarityService similarityService)
     {

--- a/src/HomelabBot/Services/RemediationService.cs
+++ b/src/HomelabBot/Services/RemediationService.cs
@@ -6,14 +6,14 @@ namespace HomelabBot.Services;
 public sealed class RemediationService
 {
     private readonly RunbookTriggerService _runbookTrigger;
-    private readonly MemoryService _memoryService;
+    private readonly InvestigationService _memoryService;
     private readonly AutoRemediationService _autoRemediation;
     private readonly IncidentSimilarityService _similarityService;
     private readonly HealingChainService _healingChain;
 
     public RemediationService(
         RunbookTriggerService runbookTrigger,
-        MemoryService memoryService,
+        InvestigationService memoryService,
         AutoRemediationService autoRemediation,
         IncidentSimilarityService similarityService,
         HealingChainService healingChain)

--- a/tests/HomelabBot.Tests/InvestigationServiceTests.cs
+++ b/tests/HomelabBot.Tests/InvestigationServiceTests.cs
@@ -3,12 +3,12 @@ using Microsoft.Extensions.Logging.Abstractions;
 
 namespace HomelabBot.Tests;
 
-public class MemoryServiceTests : IClassFixture<DatabaseFixture>
+public class InvestigationServiceTests : IClassFixture<DatabaseFixture>
 {
     private readonly DatabaseFixture _fixture;
-    private readonly MemoryService _service;
+    private readonly InvestigationService _service;
 
-    public MemoryServiceTests(DatabaseFixture fixture)
+    public InvestigationServiceTests(DatabaseFixture fixture)
     {
         _fixture = fixture;
         var runbookCompiler = new RunbookCompilerService(
@@ -17,9 +17,9 @@ public class MemoryServiceTests : IClassFixture<DatabaseFixture>
         var similarityService = new IncidentSimilarityService(
             _fixture.DbContextFactory,
             NullLogger<IncidentSimilarityService>.Instance);
-        _service = new MemoryService(
+        _service = new InvestigationService(
             _fixture.DbContextFactory,
-            NullLogger<MemoryService>.Instance,
+            NullLogger<InvestigationService>.Instance,
             runbookCompiler,
             similarityService);
     }


### PR DESCRIPTION
## Summary
- **Rename `MemoryService` → `InvestigationService`**: Better reflects purpose (investigation lifecycle, not generic memory). Updated across 9 source files + 1 test file
- **Remove dead WarRoom FKs**: `InvestigationId` and `HealingChainId` were always null — never wired up. Removed from entity (columns remain in DB, harmless)
- **Simplify `FallbackChatCompletionService`**: Pass caller's execution settings through to fallback instead of creating new `OpenAIPromptExecutionSettings` with hardcoded Temperature/MaxTokens

Net: -26 lines. All 136 tests pass.

## Test plan
- [x] `dotnet build` succeeds
- [x] `dotnet test` — all 136 tests pass
- [ ] Verify DI resolves InvestigationService correctly
- [ ] Verify fallback LLM still works with passed-through settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)