### PR TITLE
Make verification delay configurable to fix slow tests

### DIFF
--- a/src/HomelabBot/Configuration/BotConfiguration.cs
+++ b/src/HomelabBot/Configuration/BotConfiguration.cs
@@ -211,6 +211,8 @@ public sealed class AutoRemediationConfiguration
     public int MinFeedbackCount { get; init; } = 3;
 
     public int MaxRestartsPerHour { get; init; } = 3;
+
+    public int VerificationDelaySeconds { get; init; } = 30;
 }
 
 public sealed class McpServerConfiguration

--- a/src/HomelabBot/Services/AutoRemediationService.cs
+++ b/src/HomelabBot/Services/AutoRemediationService.cs
@@ -146,7 +146,7 @@ public sealed class AutoRemediationService
                 RecordCooldown(action.ContainerName);
 
                 // Wait and check state
-                await Task.Delay(TimeSpan.FromSeconds(30), ct);
+                await Task.Delay(TimeSpan.FromSeconds(_config.VerificationDelaySeconds), ct);
                 var afterState = await _dockerPlugin.GetContainerStatus(action.ContainerName);
                 action.AfterState = afterState;
                 action.Success = !afterState.Contains("not running", StringComparison.OrdinalIgnoreCase)
@@ -416,7 +416,7 @@ public sealed class AutoRemediationService
             RecordCooldown(containerName);
 
             // Wait and verify
-            await Task.Delay(TimeSpan.FromSeconds(30), ct);
+            await Task.Delay(TimeSpan.FromSeconds(_config.VerificationDelaySeconds), ct);
 
             string afterState;
             try

--- a/tests/HomelabBot.Tests/AutoRemediationServiceTests.cs
+++ b/tests/HomelabBot.Tests/AutoRemediationServiceTests.cs
@@ -109,7 +109,7 @@ public class AutoRemediationServiceTests : IClassFixture<DatabaseFixture>, IDisp
     [Fact]
     public async Task TryAutoRemediate_CooldownExceeded_ReturnsSkipMessage()
     {
-        var config = new AutoRemediationConfiguration { MaxRestartsPerHour = 1 };
+        var config = new AutoRemediationConfiguration { MaxRestartsPerHour = 1, VerificationDelaySeconds = 0 };
         var svc = CreateService(config);
 
         _dockerPlugin.GetContainerStatus(Arg.Any<string>())
@@ -172,7 +172,7 @@ public class AutoRemediationServiceTests : IClassFixture<DatabaseFixture>, IDisp
     [Fact]
     public async Task TryAutoRemediate_NonCritical_ExecutesRemediation()
     {
-        var svc = CreateService();
+        var svc = CreateService(new AutoRemediationConfiguration { VerificationDelaySeconds = 0 });
 
         _dockerPlugin.GetContainerStatus(Arg.Any<string>())
             .Returns("Status: running");


### PR DESCRIPTION
## Summary
- Add `VerificationDelaySeconds` to `AutoRemediationConfiguration` (default 30s, unchanged in prod)
- Replace two hardcoded `Task.Delay(30s)` calls in `AutoRemediationService`
- Override to 0 in tests that hit execution path

## Test plan
- [x] `dotnet test` passes: 136 tests in ~600ms (down from ~60s)
- [ ] CI workflow passes with similar speedup

🤖 Generated with [Claude Code](https://claude.com/claude-code)