### PR TITLE
Add production-ready logging across the project

### DIFF
--- a/src/HomelabBot/Commands/HomeLabCommands.cs
+++ b/src/HomelabBot/Commands/HomeLabCommands.cs
@@ -53,7 +53,7 @@ public class HomeLabCommands : ApplicationCommandModule
 
         try
         {
-            _logger.LogDebug("Containers command invoked by {User}", ctx.User.Username);
+            _logger.LogInformation("Containers command invoked by {User}", ctx.User.Username);
 
             var containers = await _dockerPlugin.ListContainers();
 
@@ -83,7 +83,7 @@ public class HomeLabCommands : ApplicationCommandModule
 
         try
         {
-            _logger.LogDebug("Container command invoked for {Container} by {User}",
+            _logger.LogInformation("Container command invoked for {Container} by {User}",
                 containerName, ctx.User.Username);
 
             var status = await _dockerPlugin.GetContainerStatus(containerName);
@@ -115,7 +115,7 @@ public class HomeLabCommands : ApplicationCommandModule
 
         try
         {
-            _logger.LogDebug("Logs command invoked for {Container} by {User}",
+            _logger.LogInformation("Logs command invoked for {Container} by {User}",
                 containerName, ctx.User.Username);
 
             var logs = await _dockerPlugin.GetContainerLogsFromDocker(containerName, (int)lines);
@@ -258,7 +258,7 @@ public class HomeLabCommands : ApplicationCommandModule
 
         try
         {
-            _logger.LogDebug("Knowledge command invoked by {User}", ctx.User.Username);
+            _logger.LogInformation("Knowledge command invoked by {User}", ctx.User.Username);
 
             var knowledge = await _knowledgePlugin.RecallKnowledge(topic);
 
@@ -286,7 +286,7 @@ public class HomeLabCommands : ApplicationCommandModule
 
         try
         {
-            _logger.LogDebug("Health command invoked by {User}", ctx.User.Username);
+            _logger.LogInformation("Health command invoked by {User}", ctx.User.Username);
 
             var data = await _summaryAggregator.AggregateAsync();
             var result = _healthScoreService.CalculateScore(data);
@@ -356,7 +356,7 @@ public class HomeLabCommands : ApplicationCommandModule
 
         try
         {
-            _logger.LogDebug("LogsAnalyze command invoked by {User} for {Container}",
+            _logger.LogInformation("LogsAnalyze command invoked by {User} for {Container}",
                 ctx.User.Username, container ?? "all");
 
             var threadId = (ulong)DateTimeOffset.UtcNow.ToUnixTimeSeconds();
@@ -428,7 +428,7 @@ public class HomeLabCommands : ApplicationCommandModule
 
         try
         {
-            _logger.LogDebug("Summary command invoked by {User}", ctx.User.Username);
+            _logger.LogInformation("Summary command invoked by {User}", ctx.User.Username);
 
             var data = await _summaryAggregator.AggregateAsync();
             var analysis = await GenerateSummaryAnalysisAsync(data);
@@ -512,7 +512,7 @@ public class HomeLabCommands : ApplicationCommandModule
 
         try
         {
-            _logger.LogDebug("Recall command invoked by {User} for '{Query}'", ctx.User.Username, query);
+            _logger.LogInformation("Recall command invoked by {User} for '{Query}'", ctx.User.Username, query);
 
             var results = await _conversationService.SearchConversationsAsync(query);
 
@@ -560,7 +560,7 @@ public class HomeLabCommands : ApplicationCommandModule
 
         try
         {
-            _logger.LogDebug("Roast command invoked by {User}", ctx.User.Username);
+            _logger.LogInformation("Roast command invoked by {User}", ctx.User.Username);
 
             var prompt = """
                 Look around the homelab using your tools. Check multiple sources:
@@ -600,7 +600,7 @@ public class HomeLabCommands : ApplicationCommandModule
 
         try
         {
-            _logger.LogDebug("RandomFact command invoked by {User}", ctx.User.Username);
+            _logger.LogInformation("RandomFact command invoked by {User}", ctx.User.Username);
 
             var prompt = """
                 Explore the homelab using your tools and discover something interesting.
@@ -640,7 +640,7 @@ public class HomeLabCommands : ApplicationCommandModule
 
         try
         {
-            _logger.LogDebug("Auto command invoked by {User} with action {Action}", ctx.User.Username, action);
+            _logger.LogInformation("Auto command invoked by {User} with action {Action}", ctx.User.Username, action);
 
             string response;
             switch (action)

--- a/src/HomelabBot/Controllers/ConversationsController.cs
+++ b/src/HomelabBot/Controllers/ConversationsController.cs
@@ -10,10 +10,12 @@ namespace HomelabBot.Controllers;
 public class ConversationsController : ControllerBase
 {
     private readonly IDbContextFactory<HomelabDbContext> _dbFactory;
+    private readonly ILogger<ConversationsController> _logger;
 
-    public ConversationsController(IDbContextFactory<HomelabDbContext> dbFactory)
+    public ConversationsController(IDbContextFactory<HomelabDbContext> dbFactory, ILogger<ConversationsController> logger)
     {
         _dbFactory = dbFactory;
+        _logger = logger;
     }
 
     [HttpGet]
@@ -22,6 +24,8 @@ public class ConversationsController : ControllerBase
         [FromQuery] int pageSize = 20,
         CancellationToken ct = default)
     {
+        _logger.LogInformation("Listing conversations Page={Page} PageSize={PageSize}", page, pageSize);
+
         await using var db = await this._dbFactory.CreateDbContextAsync(ct);
 
         var totalCount = await db.Conversations.CountAsync(ct);
@@ -55,8 +59,11 @@ public class ConversationsController : ControllerBase
         string threadId,
         CancellationToken ct = default)
     {
+        _logger.LogInformation("Getting conversation ThreadId={ThreadId}", threadId);
+
         if (!ulong.TryParse(threadId, out var tid))
         {
+            _logger.LogWarning("Invalid thread ID format ThreadId={ThreadId}", threadId);
             return this.BadRequest("Invalid thread ID");
         }
 
@@ -68,6 +75,7 @@ public class ConversationsController : ControllerBase
 
         if (conversation is null)
         {
+            _logger.LogWarning("Conversation not found ThreadId={ThreadId}", threadId);
             return this.NotFound();
         }
 

--- a/src/HomelabBot/Controllers/InvestigationsController.cs
+++ b/src/HomelabBot/Controllers/InvestigationsController.cs
@@ -10,11 +10,13 @@ public class InvestigationsController : ControllerBase
 {
     private readonly InvestigationService _memoryService;
     private readonly IncidentSimilarityService _similarityService;
+    private readonly ILogger<InvestigationsController> _logger;
 
-    public InvestigationsController(InvestigationService memoryService, IncidentSimilarityService similarityService)
+    public InvestigationsController(InvestigationService memoryService, IncidentSimilarityService similarityService, ILogger<InvestigationsController> logger)
     {
         _memoryService = memoryService;
         _similarityService = similarityService;
+        _logger = logger;
     }
 
     [HttpGet]
@@ -24,6 +26,8 @@ public class InvestigationsController : ControllerBase
         [FromQuery] bool? resolved = null,
         CancellationToken ct = default)
     {
+        _logger.LogInformation("Listing investigations Page={Page} PageSize={PageSize} Resolved={Resolved}", page, pageSize, resolved);
+
         var (items, totalCount) = await _memoryService.GetInvestigationsAsync(page, pageSize, resolved);
 
         return Ok(new PagedResult<InvestigationDto>
@@ -51,6 +55,7 @@ public class InvestigationsController : ControllerBase
 
         if (item is null)
         {
+            _logger.LogWarning("Investigation not found Id={Id}", id);
             return NotFound();
         }
 
@@ -77,6 +82,8 @@ public class InvestigationsController : ControllerBase
     public async Task<ActionResult<InvestigationDetailDto>> Create(
         [FromBody] CreateInvestigationRequest request)
     {
+        _logger.LogInformation("Creating investigation Trigger={Trigger}", request.Trigger);
+
         var investigation = await _memoryService.StartInvestigationAsync(
             request.ThreadId ?? 0,
             request.Trigger);
@@ -98,14 +105,18 @@ public class InvestigationsController : ControllerBase
         int id,
         [FromBody] CreateStepRequest request)
     {
+        _logger.LogInformation("Adding step to investigation Id={Id}", id);
+
         var investigation = await _memoryService.GetInvestigationByIdAsync(id);
         if (investigation is null)
         {
+            _logger.LogWarning("Investigation not found Id={Id}", id);
             return NotFound();
         }
 
         if (investigation.Resolved)
         {
+            _logger.LogWarning("Cannot add step to resolved investigation Id={Id}", id);
             return BadRequest("Cannot add steps to a resolved investigation");
         }
 
@@ -130,10 +141,13 @@ public class InvestigationsController : ControllerBase
         int id,
         [FromBody] ResolveInvestigationRequest request)
     {
+        _logger.LogInformation("Resolving investigation Id={Id}", id);
+
         var investigation = await _memoryService.ResolveInvestigationAsync(id, request.Resolution);
 
         if (investigation is null)
         {
+            _logger.LogWarning("Investigation not found Id={Id}", id);
             return NotFound();
         }
 
@@ -161,6 +175,8 @@ public class InvestigationsController : ControllerBase
         [FromQuery] string symptom,
         [FromQuery] int limit = 5)
     {
+        _logger.LogInformation("Searching investigations Symptom={Symptom} Limit={Limit}", symptom, limit);
+
         var items = await _similarityService.FindSimilarAsync(symptom, limit: limit);
         if (items.Count == 0)
         {

--- a/src/HomelabBot/Controllers/KnowledgeController.cs
+++ b/src/HomelabBot/Controllers/KnowledgeController.cs
@@ -10,10 +10,12 @@ namespace HomelabBot.Controllers;
 public class KnowledgeController : ControllerBase
 {
     private readonly IDbContextFactory<HomelabDbContext> _dbFactory;
+    private readonly ILogger<KnowledgeController> _logger;
 
-    public KnowledgeController(IDbContextFactory<HomelabDbContext> dbFactory)
+    public KnowledgeController(IDbContextFactory<HomelabDbContext> dbFactory, ILogger<KnowledgeController> logger)
     {
         _dbFactory = dbFactory;
+        _logger = logger;
     }
 
     [HttpGet]
@@ -22,6 +24,8 @@ public class KnowledgeController : ControllerBase
         [FromQuery] bool? isValid = null,
         CancellationToken ct = default)
     {
+        _logger.LogInformation("Listing knowledge Topic={Topic} IsValid={IsValid}", topic, isValid);
+
         await using var db = await _dbFactory.CreateDbContextAsync(ct);
 
         var query = db.Knowledge.AsQueryable();
@@ -65,6 +69,7 @@ public class KnowledgeController : ControllerBase
         var item = await db.Knowledge.FindAsync([id], ct);
         if (item is null)
         {
+            _logger.LogWarning("Knowledge not found Id={Id}", id);
             return NotFound();
         }
 
@@ -88,6 +93,8 @@ public class KnowledgeController : ControllerBase
         [FromBody] CreateKnowledgeRequest request,
         CancellationToken ct = default)
     {
+        _logger.LogInformation("Creating knowledge Topic={Topic}", request.Topic);
+
         await using var db = await _dbFactory.CreateDbContextAsync(ct);
 
         var item = new Knowledge
@@ -123,11 +130,14 @@ public class KnowledgeController : ControllerBase
         [FromBody] UpdateKnowledgeRequest request,
         CancellationToken ct = default)
     {
+        _logger.LogInformation("Updating knowledge Id={Id}", id);
+
         await using var db = await _dbFactory.CreateDbContextAsync(ct);
 
         var item = await db.Knowledge.FindAsync([id], ct);
         if (item is null)
         {
+            _logger.LogWarning("Knowledge not found Id={Id}", id);
             return NotFound();
         }
 
@@ -176,11 +186,14 @@ public class KnowledgeController : ControllerBase
     [HttpDelete("{id:int}")]
     public async Task<ActionResult> Delete(int id, CancellationToken ct = default)
     {
+        _logger.LogInformation("Deleting knowledge Id={Id}", id);
+
         await using var db = await _dbFactory.CreateDbContextAsync(ct);
 
         var item = await db.Knowledge.FindAsync([id], ct);
         if (item is null)
         {
+            _logger.LogWarning("Knowledge not found Id={Id}", id);
             return NotFound();
         }
 

--- a/src/HomelabBot/Controllers/TelemetryController.cs
+++ b/src/HomelabBot/Controllers/TelemetryController.cs
@@ -10,10 +10,12 @@ namespace HomelabBot.Controllers;
 public class TelemetryController : ControllerBase
 {
     private readonly IDbContextFactory<HomelabDbContext> _dbFactory;
+    private readonly ILogger<TelemetryController> _logger;
 
-    public TelemetryController(IDbContextFactory<HomelabDbContext> dbFactory)
+    public TelemetryController(IDbContextFactory<HomelabDbContext> dbFactory, ILogger<TelemetryController> logger)
     {
         _dbFactory = dbFactory;
+        _logger = logger;
     }
 
     [HttpGet]
@@ -24,6 +26,8 @@ public class TelemetryController : ControllerBase
         [FromQuery] bool? success = null,
         CancellationToken ct = default)
     {
+        _logger.LogInformation("Listing telemetry Page={Page} PageSize={PageSize} ThreadId={ThreadId} Success={Success}", page, pageSize, threadId, success);
+
         await using var db = await _dbFactory.CreateDbContextAsync(ct);
 
         var query = db.LlmInteractions.AsQueryable();
@@ -71,6 +75,8 @@ public class TelemetryController : ControllerBase
     [HttpGet("{id:int}")]
     public async Task<ActionResult<LlmInteractionDetailDto>> GetById(int id, CancellationToken ct = default)
     {
+        _logger.LogInformation("Getting telemetry interaction Id={Id}", id);
+
         await using var db = await _dbFactory.CreateDbContextAsync(ct);
 
         var item = await db.LlmInteractions
@@ -79,6 +85,7 @@ public class TelemetryController : ControllerBase
 
         if (item is null)
         {
+            _logger.LogWarning("Telemetry interaction not found Id={Id}", id);
             return NotFound();
         }
 
@@ -117,6 +124,8 @@ public class TelemetryController : ControllerBase
         [FromQuery] int days = 7,
         CancellationToken ct = default)
     {
+        _logger.LogInformation("Getting telemetry stats Days={Days}", days);
+
         await using var db = await _dbFactory.CreateDbContextAsync(ct);
 
         var since = DateTime.UtcNow.AddDays(-days);

--- a/src/HomelabBot/Mcp/McpApiKeyMiddleware.cs
+++ b/src/HomelabBot/Mcp/McpApiKeyMiddleware.cs
@@ -9,11 +9,13 @@ public sealed class McpApiKeyMiddleware
 {
     private readonly RequestDelegate _next;
     private readonly string _apiKey;
+    private readonly ILogger<McpApiKeyMiddleware> _logger;
 
-    public McpApiKeyMiddleware(RequestDelegate next, IOptions<McpServerConfiguration> config)
+    public McpApiKeyMiddleware(RequestDelegate next, IOptions<McpServerConfiguration> config, ILogger<McpApiKeyMiddleware> logger)
     {
         _next = next;
         _apiKey = config.Value.ApiKey;
+        _logger = logger;
     }
 
     public async Task InvokeAsync(HttpContext context)
@@ -31,10 +33,13 @@ public sealed class McpApiKeyMiddleware
                 || tokenBytes.Length != apiKeyBytes.Length
                 || !CryptographicOperations.FixedTimeEquals(tokenBytes, apiKeyBytes))
             {
+                _logger.LogWarning("MCP auth failed for {Path} from {RemoteIp}", context.Request.Path, context.Connection.RemoteIpAddress);
                 context.Response.StatusCode = 401;
                 await context.Response.WriteAsync("Unauthorized");
                 return;
             }
+
+            _logger.LogInformation("MCP request authenticated for {Path}", context.Request.Path);
         }
 
         await _next(context);

--- a/src/HomelabBot/Plugins/AlertmanagerPlugin.cs
+++ b/src/HomelabBot/Plugins/AlertmanagerPlugin.cs
@@ -32,7 +32,7 @@ public sealed class AlertmanagerPlugin
     [Description("Gets all currently firing alerts from Alertmanager.")]
     public async Task<string> GetActiveAlerts()
     {
-        _logger.LogDebug("Getting active alerts...");
+        _logger.LogInformation("Getting active alerts...");
 
         try
         {
@@ -102,7 +102,7 @@ public sealed class AlertmanagerPlugin
     [Description("Gets alerts grouped by labels (shows how alerts are organized).")]
     public async Task<string> GetAlertGroups()
     {
-        _logger.LogDebug("Getting alert groups...");
+        _logger.LogInformation("Getting alert groups...");
 
         try
         {
@@ -192,7 +192,7 @@ public sealed class AlertmanagerPlugin
     [Description("Lists all active silences.")]
     public async Task<string> ListSilences()
     {
-        _logger.LogDebug("Listing silences...");
+        _logger.LogInformation("Listing silences...");
 
         try
         {

--- a/src/HomelabBot/Plugins/DockerPlugin.cs
+++ b/src/HomelabBot/Plugins/DockerPlugin.cs
@@ -25,7 +25,7 @@ public class DockerPlugin
     [Description("Lists all Docker containers with their status. Returns container name, status, and image.")]
     public async Task<string> ListContainers()
     {
-        _logger.LogDebug("Listing Docker containers...");
+        _logger.LogInformation("Listing Docker containers...");
 
         var containers = await _client.Containers.ListContainersAsync(new ContainersListParameters
         {
@@ -68,7 +68,7 @@ public class DockerPlugin
     [Description("Gets detailed status information for a specific container by name or ID.")]
     public virtual async Task<string> GetContainerStatus([Description("Container name or ID")] string containerName)
     {
-        _logger.LogDebug("Getting status for container {Container}...", containerName);
+        _logger.LogInformation("Getting status for container {Container}...", containerName);
 
         var container = await FindContainerAsync(containerName);
         if (container == null)
@@ -221,7 +221,7 @@ public class DockerPlugin
         [Description("Container name or ID")] string containerName,
         [Description("Number of lines to retrieve (default 50)")] int lines = 50)
     {
-        _logger.LogDebug("Getting logs for container {Container}...", containerName);
+        _logger.LogInformation("Getting logs for container {Container}...", containerName);
 
         var container = await FindContainerAsync(containerName);
         if (container == null)
@@ -276,7 +276,7 @@ public class DockerPlugin
     [Description("Lists all Docker networks with their connected containers. Useful for understanding service relationships.")]
     public async Task<string> ListNetworks()
     {
-        _logger.LogDebug("Listing Docker networks...");
+        _logger.LogInformation("Listing Docker networks...");
 
         // Build network → containers mapping from container data (more reliable than network inspect)
         var containers = await _client.Containers.ListContainersAsync(

--- a/src/HomelabBot/Plugins/GrafanaPlugin.cs
+++ b/src/HomelabBot/Plugins/GrafanaPlugin.cs
@@ -42,7 +42,7 @@ public sealed class GrafanaPlugin
     [Description("Lists all available Grafana dashboards with their UIDs and titles.")]
     public async Task<string> ListDashboards()
     {
-        _logger.LogDebug("Listing Grafana dashboards...");
+        _logger.LogInformation("Listing Grafana dashboards...");
 
         try
         {
@@ -87,7 +87,7 @@ public sealed class GrafanaPlugin
     [Description("Gets information about a specific dashboard including its panels.")]
     public async Task<string> GetDashboardInfo([Description("Dashboard UID (from ListDashboards)")] string uid)
     {
-        _logger.LogDebug("Getting dashboard info for {Uid}...", uid);
+        _logger.LogInformation("Getting dashboard info for {Uid}...", uid);
 
         try
         {
@@ -148,7 +148,7 @@ public sealed class GrafanaPlugin
         [Description("Optional panel ID to render only that panel")] int? panelId = null,
         [Description("Time range like '1h', '6h', '24h', '7d' (default 1h)")] string timeRange = "1h")
     {
-        _logger.LogDebug("Rendering dashboard screenshot for {Uid}...", uid);
+        _logger.LogInformation("Rendering dashboard screenshot for {Uid}...", uid);
 
         var duration = FormattingHelpers.ParseDuration(timeRange);
         var from = DateTimeOffset.UtcNow.Subtract(duration).ToUnixTimeMilliseconds();
@@ -175,7 +175,7 @@ public sealed class GrafanaPlugin
     [Description("Gets the current health status of Grafana.")]
     public async Task<string> GetGrafanaHealth()
     {
-        _logger.LogDebug("Checking Grafana health...");
+        _logger.LogInformation("Checking Grafana health...");
 
         try
         {

--- a/src/HomelabBot/Plugins/HomeAssistantPlugin.cs
+++ b/src/HomelabBot/Plugins/HomeAssistantPlugin.cs
@@ -39,7 +39,7 @@ public sealed class HomeAssistantPlugin
     [Description("Gets the current state of a Home Assistant entity by its entity_id.")]
     public async Task<string> GetEntityState([Description("Entity ID (e.g., sensor.temperature, light.living_room)")] string entityId)
     {
-        _logger.LogDebug("Getting state for entity {EntityId}...", entityId);
+        _logger.LogInformation("Getting state for entity {EntityId}...", entityId);
 
         try
         {
@@ -95,7 +95,7 @@ public sealed class HomeAssistantPlugin
     [Description("Lists all entities in a specific Home Assistant domain (e.g., light, switch, sensor).")]
     public async Task<string> ListEntities([Description("Domain to list (e.g., light, switch, sensor, automation)")] string domain)
     {
-        _logger.LogDebug("Listing entities for domain {Domain}...", domain);
+        _logger.LogInformation("Listing entities for domain {Domain}...", domain);
 
         try
         {
@@ -239,7 +239,7 @@ public sealed class HomeAssistantPlugin
     [Description("Lists all available Home Assistant automations.")]
     public async Task<string> ListAutomations()
     {
-        _logger.LogDebug("Listing automations...");
+        _logger.LogInformation("Listing automations...");
 
         try
         {

--- a/src/HomelabBot/Plugins/InvestigationPlugin.cs
+++ b/src/HomelabBot/Plugins/InvestigationPlugin.cs
@@ -182,7 +182,7 @@ public sealed class InvestigationPlugin
     public async Task<string> SearchPastIncidents(
         [Description("Symptom or keywords to search for")] string symptom)
     {
-        _logger.LogDebug("Searching past incidents for '{Symptom}'", symptom);
+        _logger.LogInformation("Searching past incidents for '{Symptom}'", symptom);
 
         var incidents = await _similarityService.FindSimilarAsync(symptom);
 
@@ -222,7 +222,7 @@ public sealed class InvestigationPlugin
     public async Task<string> SearchConversations(
         [Description("Keywords to search for (e.g. 'Plex crashed', 'high CPU', 'TLS cert')")] string query)
     {
-        _logger.LogDebug("Searching conversations for '{Query}'", query);
+        _logger.LogInformation("Searching conversations for '{Query}'", query);
 
         var results = await _conversationService.SearchConversationsAsync(query);
 

--- a/src/HomelabBot/Plugins/KnowledgePlugin.cs
+++ b/src/HomelabBot/Plugins/KnowledgePlugin.cs
@@ -26,7 +26,7 @@ public sealed class KnowledgePlugin
         [Description("The fact to remember")] string fact,
         [Description("How/when this was learned (optional)")] string? context = null)
     {
-        _logger.LogDebug("Remembering fact: [{Topic}] {Fact}", topic, fact);
+        _logger.LogInformation("Remembering fact: [{Topic}] {Fact}", topic, fact);
 
         await _knowledgeService.RememberFactAsync(topic, fact, context);
         return $"Remembered: [{topic}] {fact}";
@@ -38,7 +38,7 @@ public sealed class KnowledgePlugin
     public async Task<string> RecallKnowledge(
         [Description("Topic to recall (e.g., 'docker', 'loki', 'network', 'alias'). Leave empty for all.")] string? topic = null)
     {
-        _logger.LogDebug("Recalling knowledge for topic: {Topic}", topic ?? "all");
+        _logger.LogInformation("Recalling knowledge for topic: {Topic}", topic ?? "all");
 
         var facts = await _knowledgeService.RecallAsync(topic, includeStale: true);
 
@@ -58,7 +58,7 @@ public sealed class KnowledgePlugin
         [Description("Natural language query (e.g., 'what port is portainer on', 'docker container info')")] string query,
         Kernel kernel)
     {
-        _logger.LogDebug("Smart recalling knowledge for: {Query}", query);
+        _logger.LogInformation("Smart recalling knowledge for: {Query}", query);
 
         var chatService = kernel.GetRequiredService<IChatCompletionService>();
         var facts = await _knowledgeService.SmartRecallAsync(query, chatService);
@@ -90,7 +90,7 @@ public sealed class KnowledgePlugin
         [Description("Alias type: 'mac' for device MACs, 'container' for Docker containers, 'entity' for Home Assistant")] string aliasType,
         [Description("The user's input containing the alias")] string userInput)
     {
-        _logger.LogDebug("Resolving alias: [{Type}] {Input}", aliasType, userInput);
+        _logger.LogInformation("Resolving alias: [{Type}] {Input}", aliasType, userInput);
 
         var resolved = await _knowledgeService.ResolveAliasAsync(aliasType, userInput);
 

--- a/src/HomelabBot/Plugins/LokiPlugin.cs
+++ b/src/HomelabBot/Plugins/LokiPlugin.cs
@@ -31,7 +31,7 @@ public sealed class LokiPlugin
     [Description("Lists available log labels in Loki. Use this to discover what labels are available for querying.")]
     public async Task<string> ListLabels()
     {
-        _logger.LogDebug("Listing Loki labels...");
+        _logger.LogInformation("Listing Loki labels...");
 
         try
         {
@@ -68,7 +68,7 @@ public sealed class LokiPlugin
     [Description("Lists values for a specific label. Useful to see what containers/services are available.")]
     public async Task<string> ListLabelValues([Description("Label name (e.g., 'container_name', 'compose_service', 'job')")] string labelName)
     {
-        _logger.LogDebug("Listing values for label {Label}...", labelName);
+        _logger.LogInformation("Listing values for label {Label}...", labelName);
 
         try
         {
@@ -111,7 +111,7 @@ public sealed class LokiPlugin
         [Description("LogQL query expression (e.g., '{compose_service=\"traefik\"}' or '{container_name=~\".*traefik.*\"}')")] string query,
         [Description("Maximum number of log entries to return (default 100)")] int limit = 100)
     {
-        _logger.LogDebug("Executing LogQL query: {Query}", query);
+        _logger.LogInformation("Executing LogQL query: {Query}", query);
 
         try
         {
@@ -189,7 +189,7 @@ public sealed class LokiPlugin
         [Description("Container name (will try multiple label patterns like compose_service, container_name)")] string containerName,
         [Description("Time range like '1h', '30m', '15m' (default 1h)")] string since = "1h")
     {
-        _logger.LogDebug("Getting logs for container {Container} since {Since}", containerName, since);
+        _logger.LogInformation("Getting logs for container {Container} since {Since}", containerName, since);
 
         var duration = FormattingHelpers.ParseDuration(since);
         var now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() * 1_000_000;
@@ -271,9 +271,9 @@ public sealed class LokiPlugin
 
                 return sb.ToString();
             }
-            catch
+            catch (Exception ex)
             {
-                // Try next pattern
+                _logger.LogWarning(ex, "Loki query failed for container {Container}", containerName);
                 continue;
             }
         }
@@ -332,7 +332,7 @@ public sealed class LokiPlugin
         [Description("Time range like '1h', '6h', '24h' (default 1h)")] string since = "1h",
         string? containerName = null)
     {
-        _logger.LogDebug("Counting errors by container since {Since}", since);
+        _logger.LogInformation("Counting errors by container since {Since}", since);
 
         try
         {
@@ -368,7 +368,7 @@ public sealed class LokiPlugin
     public async Task<string> DetectCriticalPatterns(
         [Description("Time range like '1h', '6h', '24h' (default 1h)")] string since = "1h")
     {
-        _logger.LogDebug("Detecting critical patterns since {Since}", since);
+        _logger.LogInformation("Detecting critical patterns since {Since}", since);
 
         var duration = FormattingHelpers.ParseDuration(since);
         var query = "{compose_service=~\".+\",compose_service!=\"loki\"} |~ \"(?i)(\\\\bfatal\\\\b|\\\\bpanic\\\\b|\\\\boom\\\\b|out of memory|killed process|segfault)\"";
@@ -451,7 +451,7 @@ public sealed class LokiPlugin
         [Description("Time range like '1h', '30m', '15m' (default 1h)")] string since = "1h",
         string? containerName = null)
     {
-        _logger.LogDebug("Searching logs for '{SearchText}' since {Since}", searchText, since);
+        _logger.LogInformation("Searching logs for '{SearchText}' since {Since}", searchText, since);
 
         var escapedText = searchText.Replace("\"", "\\\"");
         var selector = string.IsNullOrWhiteSpace(containerName)

--- a/src/HomelabBot/Plugins/MikroTikPlugin.cs
+++ b/src/HomelabBot/Plugins/MikroTikPlugin.cs
@@ -32,7 +32,7 @@ public sealed class MikroTikPlugin
     [Description("Gets the current status of the MikroTik router including uptime, CPU, memory usage, and temperature.")]
     public async Task<string> GetRouterStatus()
     {
-        _logger.LogDebug("Getting MikroTik router status...");
+        _logger.LogInformation("Getting MikroTik router status...");
 
         var sb = new StringBuilder();
         sb.AppendLine("**MikroTik Router Status**\n");
@@ -72,7 +72,7 @@ public sealed class MikroTikPlugin
     [Description("Gets network interface statistics from the MikroTik router including bandwidth usage.")]
     public async Task<string> GetInterfaceStats()
     {
-        _logger.LogDebug("Getting interface stats...");
+        _logger.LogInformation("Getting interface stats...");
 
         try
         {
@@ -127,7 +127,7 @@ public sealed class MikroTikPlugin
     [Description("Lists connected WiFi clients with their signal strength.")]
     public async Task<string> GetWifiClients()
     {
-        _logger.LogDebug("Getting WiFi clients...");
+        _logger.LogInformation("Getting WiFi clients...");
 
         try
         {
@@ -163,7 +163,7 @@ public sealed class MikroTikPlugin
     [Description("Lists DHCP leases (connected devices) from the MikroTik router.")]
     public async Task<string> GetDhcpLeases()
     {
-        _logger.LogDebug("Getting DHCP leases...");
+        _logger.LogInformation("Getting DHCP leases...");
 
         try
         {

--- a/src/HomelabBot/Plugins/PrometheusPlugin.cs
+++ b/src/HomelabBot/Plugins/PrometheusPlugin.cs
@@ -26,7 +26,7 @@ public sealed class PrometheusPlugin
     [Description("Lists available Prometheus metric names. Use this to discover what metrics are available before querying.")]
     public async Task<string> GetAvailableMetrics([Description("Optional filter prefix (e.g., 'node_', 'container_')")] string? prefix = null)
     {
-        _logger.LogDebug("Getting available metrics with prefix: {Prefix}", prefix ?? "all");
+        _logger.LogInformation("Getting available metrics with prefix: {Prefix}", prefix ?? "all");
 
         try
         {
@@ -89,7 +89,7 @@ public sealed class PrometheusPlugin
     [Description("Executes a PromQL query against Prometheus. Returns the current value of the expression.")]
     public async Task<string> QueryPrometheus([Description("PromQL query expression")] string query)
     {
-        _logger.LogDebug("Executing PromQL query: {Query}", query);
+        _logger.LogInformation("Executing PromQL query: {Query}", query);
 
         try
         {
@@ -130,7 +130,7 @@ public sealed class PrometheusPlugin
     [Description("Gets current CPU, memory, and disk usage for the node (Ubuntu VM).")]
     public async Task<string> GetNodeStats()
     {
-        _logger.LogDebug("Getting node stats...");
+        _logger.LogInformation("Getting node stats...");
 
         var sb = new StringBuilder();
         sb.AppendLine("**Node Statistics**\n");
@@ -166,7 +166,7 @@ public sealed class PrometheusPlugin
     [Description("Gets the status of all Prometheus scrape targets. Shows which services are being monitored and their health.")]
     public async Task<string> GetTargets()
     {
-        _logger.LogDebug("Getting Prometheus targets...");
+        _logger.LogInformation("Getting Prometheus targets...");
 
         try
         {
@@ -214,7 +214,7 @@ public sealed class PrometheusPlugin
     [Description("Gets resource metrics for a specific Docker container (CPU, memory usage).")]
     public async Task<string> GetContainerMetrics([Description("Container name")] string containerName)
     {
-        _logger.LogDebug("Getting metrics for container: {Container}", containerName);
+        _logger.LogInformation("Getting metrics for container: {Container}", containerName);
 
         var sb = new StringBuilder();
         sb.AppendLine($"**Container Metrics: {containerName}**\n");

--- a/src/HomelabBot/Plugins/TrueNASPlugin.cs
+++ b/src/HomelabBot/Plugins/TrueNASPlugin.cs
@@ -38,7 +38,7 @@ public sealed class TrueNASPlugin
     [Description("Gets the health status of all ZFS pools on TrueNAS.")]
     public async Task<string> GetPoolStatus()
     {
-        _logger.LogDebug("Getting TrueNAS pool status...");
+        _logger.LogInformation("Getting TrueNAS pool status...");
 
         try
         {
@@ -103,7 +103,7 @@ public sealed class TrueNASPlugin
     [Description("Gets storage usage for all datasets on TrueNAS.")]
     public async Task<string> GetDatasetUsage()
     {
-        _logger.LogDebug("Getting dataset usage...");
+        _logger.LogInformation("Getting dataset usage...");
 
         try
         {
@@ -158,7 +158,7 @@ public sealed class TrueNASPlugin
     [Description("Gets general system information from TrueNAS including version and health.")]
     public async Task<string> GetSystemInfo()
     {
-        _logger.LogDebug("Getting TrueNAS system info...");
+        _logger.LogInformation("Getting TrueNAS system info...");
 
         var sb = new StringBuilder();
         sb.AppendLine("**TrueNAS System Info**\n");

--- a/src/HomelabBot/Program.cs
+++ b/src/HomelabBot/Program.cs
@@ -135,7 +135,7 @@ try
                     .SetSampler(new AlwaysOnSampler())
                     .AddSource("HomelabBot.Chat")
                     .AddSource("Microsoft.SemanticKernel*")
-                    .AddProcessor(new LangfuseEnrichmentProcessor())
+                    .AddProcessor(sp => new LangfuseEnrichmentProcessor(sp.GetRequiredService<ILoggerFactory>()))
                     .AddOtlpExporter(options =>
                     {
                         options.Endpoint = new Uri(langfuseConfig.Endpoint);

--- a/src/HomelabBot/Services/AlertWebhookService.cs
+++ b/src/HomelabBot/Services/AlertWebhookService.cs
@@ -62,6 +62,7 @@ public sealed class AlertWebhookService
     {
         if (!alert.IsFiring)
         {
+            _logger.LogInformation("Alert {AlertName} resolved", alert.AlertName);
             var resolvedAnalysis = $"Alert resolved after {FormattingHelpers.FormatDuration(alert.Duration ?? TimeSpan.Zero)}.";
             var resolvedEmbed = BuildAlertEmbed(alert, resolvedAnalysis);
             await _discordService.SendDmAsync(HomelabOwner.DiscordUserId, resolvedEmbed);
@@ -72,6 +73,7 @@ public sealed class AlertWebhookService
         Data.Entities.WarRoom? warRoom = null;
         if (_warRoomService.ShouldOpenWarRoom(alert.Severity))
         {
+            _logger.LogInformation("Opening war room for {Severity} alert {AlertName}", alert.Severity, alert.AlertName);
             var trigger = $"{alert.AlertName}: {alert.Description ?? alert.Summary ?? "unknown"}";
             warRoom = await _warRoomService.OpenWarRoomAsync(trigger, alert.Severity, ct);
         }
@@ -84,6 +86,8 @@ public sealed class AlertWebhookService
             await HandleRemediationOutcomeAsync(alert, outcome, warRoom, ct);
             return;
         }
+
+        _logger.LogInformation("No automated remediation for {AlertName}, running LLM investigation", alert.AlertName);
 
         // Fall through to LLM investigation
         var analysis = await RunLlmInvestigationAsync(alert, outcome, ct);

--- a/src/HomelabBot/Services/AnomalyDetectionService.cs
+++ b/src/HomelabBot/Services/AnomalyDetectionService.cs
@@ -70,7 +70,7 @@ public sealed class AnomalyDetectionService : BackgroundService
             {
                 if (!_config.CurrentValue.Enabled)
                 {
-                    _logger.LogDebug("Anomaly detection disabled, rechecking in 1 minute");
+                    _logger.LogInformation("Anomaly detection disabled, rechecking in 1 minute");
                     await Task.Delay(TimeSpan.FromMinutes(1), stoppingToken);
                     continue;
                 }
@@ -136,7 +136,7 @@ public sealed class AnomalyDetectionService : BackgroundService
 
         if (anomalies.Count > 0)
         {
-            _logger.LogDebug("Heuristic check found {Count} anomalies", anomalies.Count);
+            _logger.LogInformation("Heuristic check found {Count} anomalies", anomalies.Count);
         }
 
         return anomalies;
@@ -270,7 +270,7 @@ public sealed class AnomalyDetectionService : BackgroundService
         }
         catch (Exception ex)
         {
-            _logger.LogDebug(ex, "Failed to check Prometheus targets");
+            _logger.LogWarning(ex, "Failed to check Prometheus targets");
         }
 
         return anomalies;
@@ -296,7 +296,7 @@ public sealed class AnomalyDetectionService : BackgroundService
         }
         catch (Exception ex)
         {
-            _logger.LogDebug(ex, "Failed to check container health");
+            _logger.LogWarning(ex, "Failed to check container health");
         }
 
         return anomalies;
@@ -322,7 +322,7 @@ public sealed class AnomalyDetectionService : BackgroundService
         }
         catch (Exception ex)
         {
-            _logger.LogDebug(ex, "Failed to check container restarts");
+            _logger.LogWarning(ex, "Failed to check container restarts");
         }
 
         return anomalies;
@@ -376,7 +376,7 @@ public sealed class AnomalyDetectionService : BackgroundService
         }
         catch (Exception ex)
         {
-            _logger.LogDebug(ex, "Failed to check router health");
+            _logger.LogWarning(ex, "Failed to check router health");
         }
 
         return anomalies;
@@ -411,7 +411,7 @@ public sealed class AnomalyDetectionService : BackgroundService
         }
         catch (Exception ex)
         {
-            _logger.LogDebug(ex, "Failed to check network traffic");
+            _logger.LogWarning(ex, "Failed to check network traffic");
         }
 
         return anomalies;
@@ -440,7 +440,7 @@ public sealed class AnomalyDetectionService : BackgroundService
         }
         catch (Exception ex)
         {
-            _logger.LogDebug(ex, "Failed to check storage pools");
+            _logger.LogWarning(ex, "Failed to check storage pools");
         }
 
         return anomalies;
@@ -467,7 +467,7 @@ public sealed class AnomalyDetectionService : BackgroundService
         }
         catch (Exception ex)
         {
-            _logger.LogDebug(ex, "Failed to check Traefik 5xx rate");
+            _logger.LogWarning(ex, "Failed to check Traefik 5xx rate");
         }
 
         return anomalies;
@@ -500,7 +500,7 @@ public sealed class AnomalyDetectionService : BackgroundService
         }
         catch (Exception ex)
         {
-            _logger.LogDebug(ex, "Failed to check cert expiry");
+            _logger.LogWarning(ex, "Failed to check cert expiry");
         }
 
         return anomalies;
@@ -525,7 +525,7 @@ public sealed class AnomalyDetectionService : BackgroundService
         }
         catch (Exception ex)
         {
-            _logger.LogDebug(ex, "Failed to check Prometheus cardinality");
+            _logger.LogWarning(ex, "Failed to check Prometheus cardinality");
         }
 
         return anomalies;

--- a/src/HomelabBot/Services/AutoRemediationService.cs
+++ b/src/HomelabBot/Services/AutoRemediationService.cs
@@ -70,6 +70,7 @@ public sealed class AutoRemediationService
 
         if (!_enabled)
         {
+            _logger.LogInformation("Auto-remediation disabled, skipping");
             return null;
         }
 
@@ -82,6 +83,7 @@ public sealed class AutoRemediationService
 
         if (qualifiedRunbooks.Count == 0)
         {
+            _logger.LogInformation("No qualified runbooks for auto-remediation");
             return null;
         }
 
@@ -89,6 +91,7 @@ public sealed class AutoRemediationService
         var containerName = ExtractContainerName(alert);
         if (containerName == null)
         {
+            _logger.LogInformation("Could not extract container name from alert");
             return null;
         }
 
@@ -111,6 +114,7 @@ public sealed class AutoRemediationService
 
         if (isCritical)
         {
+            _logger.LogInformation("Container {Container} is critical, requiring confirmation", containerName);
             return await SuggestRemediationAsync(containerName, bestRunbook, ct);
         }
 

--- a/src/HomelabBot/Services/ConfirmationService.cs
+++ b/src/HomelabBot/Services/ConfirmationService.cs
@@ -60,16 +60,23 @@ public sealed class ConfirmationService
 
         _pendingConfirmations[confirmId] = pending;
 
-        _logger.LogDebug("Created confirmation request {ConfirmId} for action: {Action}", confirmId, action);
+        _logger.LogInformation("Created confirmation request {ConfirmId} for action: {Action}", confirmId, action);
 
         // Schedule cleanup
         _ = Task.Run(async () =>
         {
-            await Task.Delay(_confirmationTimeout);
-            if (_pendingConfirmations.TryRemove(confirmId, out var expired))
+            try
             {
-                _logger.LogDebug("Confirmation {ConfirmId} expired", confirmId);
-                await UpdateMessageAsExpired(expired.Message);
+                await Task.Delay(_confirmationTimeout);
+                if (_pendingConfirmations.TryRemove(confirmId, out var expired))
+                {
+                    _logger.LogInformation("Confirmation {ConfirmId} expired", confirmId);
+                    await UpdateMessageAsExpired(expired.Message);
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to clean up expired confirmation {ConfirmId}", confirmId);
             }
         });
 
@@ -161,12 +168,12 @@ public sealed class ConfirmationService
         }
         catch (OperationCanceledException)
         {
-            _logger.LogDebug("Confirmation {ConfirmId} wait was cancelled", confirmId);
+            _logger.LogInformation("Confirmation {ConfirmId} wait was cancelled", confirmId);
             return false;
         }
     }
 
-    private static async Task UpdateMessageAsExpired(DiscordMessage message)
+    private async Task UpdateMessageAsExpired(DiscordMessage message)
     {
         try
         {
@@ -178,9 +185,9 @@ public sealed class ConfirmationService
 
             await message.ModifyAsync(new DiscordMessageBuilder().WithEmbed(embed));
         }
-        catch
+        catch (Exception ex)
         {
-            // Message may have been deleted
+            _logger.LogWarning(ex, "Failed to update message as expired");
         }
     }
 

--- a/src/HomelabBot/Services/ContagionTrackerService.cs
+++ b/src/HomelabBot/Services/ContagionTrackerService.cs
@@ -71,7 +71,7 @@ public sealed class ContagionTrackerService
             _ => "critical"
         };
 
-        _logger.LogDebug("Blast radius for {Container}: {Count} affected services ({Risk})",
+        _logger.LogInformation("Blast radius for {Container}: {Count} affected services ({Risk})",
             sourceContainer, affected.Count, riskLevel);
 
         return new BlastRadiusReport

--- a/src/HomelabBot/Services/ConversationService.cs
+++ b/src/HomelabBot/Services/ConversationService.cs
@@ -51,7 +51,7 @@ public sealed class ConversationService
                 }
             }
 
-            _logger.LogDebug("Loaded {Count} messages for thread {ThreadId}", conversation.Messages.Count, threadId);
+            _logger.LogInformation("Loaded {Count} messages for thread {ThreadId}", conversation.Messages.Count, threadId);
         }
         else
         {
@@ -63,7 +63,7 @@ public sealed class ConversationService
             db.Conversations.Add(conversation);
             await db.SaveChangesAsync(ct);
 
-            _logger.LogDebug("Created new conversation for thread {ThreadId}", threadId);
+            _logger.LogInformation("Created new conversation for thread {ThreadId}", threadId);
         }
 
         _histories[threadId] = history;
@@ -185,7 +185,7 @@ public sealed class ConversationService
     {
         if (_histories.TryRemove(threadId, out _))
         {
-            _logger.LogDebug("Cleared conversation history for thread {ThreadId}", threadId);
+            _logger.LogInformation("Cleared conversation history for thread {ThreadId}", threadId);
         }
     }
 

--- a/src/HomelabBot/Services/DailySummaryService.cs
+++ b/src/HomelabBot/Services/DailySummaryService.cs
@@ -30,7 +30,7 @@ public sealed class DailySummaryService : ScheduledBackgroundService
     protected override ILogger Logger => _logger;
 
     protected override TimeSpan GetDelay() =>
-        ScheduleHelper.CalculateDelayUntilNextRun(_config.CurrentValue.ScheduleTime, _config.CurrentValue.TimeZone);
+        ScheduleHelper.CalculateDelayUntilNextRun(_config.CurrentValue.ScheduleTime, _config.CurrentValue.TimeZone, logger: _logger);
 
     protected override async Task RunIterationAsync(CancellationToken ct)
     {

--- a/src/HomelabBot/Services/DiscordBotService.cs
+++ b/src/HomelabBot/Services/DiscordBotService.cs
@@ -254,9 +254,9 @@ public sealed class DiscordBotService : BackgroundService
                         .WithContent("Something went wrong processing your feedback.")
                         .AsEphemeral());
             }
-            catch
+            catch (Exception innerEx)
             {
-                // Already responded or timed out
+                _logger.LogWarning(innerEx, "Failed to send error response for interaction");
             }
         }
     }
@@ -340,9 +340,9 @@ public sealed class DiscordBotService : BackgroundService
                         .WithContent("Failed to process remediation response.")
                         .AsEphemeral());
             }
-            catch
+            catch (Exception innerEx)
             {
-                // Response already sent
+                _logger.LogWarning(innerEx, "Failed to send error response for remediation interaction");
             }
         }
     }
@@ -376,7 +376,7 @@ public sealed class DiscordBotService : BackgroundService
         // Use thread ID for conversation, or channel ID if not in thread
         var conversationId = e.Channel.IsThread ? e.Channel.Id : e.Message.Id;
 
-        _logger.LogDebug("Processing message from {Author} in {Channel}",
+        _logger.LogInformation("Processing message from {Author} in {Channel}",
             e.Author.Username, e.Channel.Name);
 
         try
@@ -443,7 +443,7 @@ public sealed class DiscordBotService : BackgroundService
         var threadId = SmartNotification.CurrentDailyThreadId;
         SmartNotification.MarkConversationActive();
 
-        _logger.LogDebug("Processing DM from owner, using daily cycle threadId={ThreadId}", threadId);
+        _logger.LogInformation("Processing DM from owner, using daily cycle threadId={ThreadId}", threadId);
 
         try
         {
@@ -649,12 +649,12 @@ public sealed class DiscordBotService : BackgroundService
                 {
                     var member = await guild.GetMemberAsync(userId);
                     var dm = await member.CreateDmChannelAsync();
-                    _logger.LogDebug("Found DM channel for user {UserId}", userId);
+                    _logger.LogInformation("Found DM channel for user {UserId}", userId);
                     return dm;
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogDebug(ex, "User {UserId} not found in guild {Guild}", userId, guild.Name);
+                    _logger.LogInformation(ex, "User {UserId} not found in guild {Guild}", userId, guild.Name);
                 }
             }
 

--- a/src/HomelabBot/Services/FallbackChatCompletionService.cs
+++ b/src/HomelabBot/Services/FallbackChatCompletionService.cs
@@ -46,8 +46,10 @@ public sealed class FallbackChatCompletionService : IChatCompletionService
         {
             _logger.LogWarning(ex, "Primary LLM failed, falling back to OpenRouter");
 
-            return await _fallback.GetChatMessageContentsAsync(
+            var result = await _fallback.GetChatMessageContentsAsync(
                 chatHistory, executionSettings, kernel, cancellationToken);
+            _logger.LogInformation("Fallback LLM completed successfully");
+            return result;
         }
     }
 

--- a/src/HomelabBot/Services/HealingChainService.cs
+++ b/src/HomelabBot/Services/HealingChainService.cs
@@ -48,6 +48,8 @@ public sealed class HealingChainService
             return null;
         }
 
+        _logger.LogInformation("Planning healing chain for symptom: {Symptom}", symptom);
+
         if (_activeChains.Count >= _config.MaxConcurrentChains)
         {
             _logger.LogWarning("Max concurrent healing chains ({Max}) reached, skipping", _config.MaxConcurrentChains);
@@ -62,6 +64,7 @@ public sealed class HealingChainService
         var steps = await PlanRecoveryAsync(symptom, containerName, pastContext, ct);
         if (steps == null || steps.Count == 0)
         {
+            _logger.LogWarning("Healing chain returned no steps for {Symptom}", symptom);
             return new HealingChainResult
             {
                 ChainId = 0,
@@ -250,6 +253,9 @@ public sealed class HealingChainService
 
         await UpdateChainStatusAsync(chain.Id, finalStatus, executionLog, runbookId, ct,
             chain.RequiredConfirmation);
+
+        _logger.LogInformation("Healing chain completed: {Status}, {StepsExecuted}/{TotalSteps} steps",
+            finalStatus, stepsExecuted, steps.Count);
 
         var message = success
             ? $"Healing chain completed: {stepsExecuted}/{steps.Count} steps executed."

--- a/src/HomelabBot/Services/HealthScoreBackgroundService.cs
+++ b/src/HomelabBot/Services/HealthScoreBackgroundService.cs
@@ -50,7 +50,6 @@ public sealed class HealthScoreBackgroundService : ScheduledBackgroundService
         var previousScore = await _healthScoreService.GetScoreAtWindowStartAsync(TimeSpan.FromHours(1), ct);
 
         await _healthScoreService.RecordScoreAsync(result, ct);
-        _logger.LogDebug("Recorded health score: {Score}/100", result.Score);
 
         await _healthScoreService.PruneOldRecordsAsync(TimeSpan.FromDays(30), ct);
 

--- a/src/HomelabBot/Services/HealthScoreService.cs
+++ b/src/HomelabBot/Services/HealthScoreService.cs
@@ -93,6 +93,7 @@ public sealed class HealthScoreService
             ConnectivityDeductions = result.ConnectivityDeductions,
         });
         await db.SaveChangesAsync(ct);
+        _logger.LogInformation("Recorded health score: {Score}/100", result.Score);
     }
 
     public async Task<string> GetTrendAsync(TimeSpan window, CancellationToken ct = default)
@@ -155,7 +156,7 @@ public sealed class HealthScoreService
 
         if (deleted > 0)
         {
-            _logger.LogDebug("Pruned {Count} old health score records", deleted);
+            _logger.LogInformation("Pruned {Count} old health score records", deleted);
         }
     }
 

--- a/src/HomelabBot/Services/IncidentSimilarityService.cs
+++ b/src/HomelabBot/Services/IncidentSimilarityService.cs
@@ -106,7 +106,7 @@ public sealed class IncidentSimilarityService
 
         if (results.Count > 0)
         {
-            _logger.LogDebug("Found {Count} similar incidents for '{Symptom}' (top score: {Score})",
+            _logger.LogInformation("Found {Count} similar incidents for '{Symptom}' (top score: {Score})",
                 results.Count, symptom, results[0].SimilarityScore);
         }
 

--- a/src/HomelabBot/Services/InvestigationService.cs
+++ b/src/HomelabBot/Services/InvestigationService.cs
@@ -117,7 +117,7 @@ public sealed class InvestigationService
         db.InvestigationSteps.Add(step);
         await db.SaveChangesAsync();
 
-        _logger.LogDebug("Recorded step for investigation {Id}: {Action}", investigationId, action);
+        _logger.LogInformation("Recorded step for investigation {Id}: {Action}", investigationId, action);
     }
 
     public async Task<Investigation?> ResolveInvestigationAsync(int investigationId, string resolution)
@@ -220,7 +220,7 @@ public sealed class InvestigationService
         }
 
         await db.SaveChangesAsync();
-        _logger.LogDebug("Recorded {Feedback} feedback for runbook {Id}", helpful ? "positive" : "negative", runbookId);
+        _logger.LogInformation("Recorded {Feedback} feedback for runbook {Id}", helpful ? "positive" : "negative", runbookId);
     }
 
     public async Task<string> GenerateIncidentContextAsync(string symptom)

--- a/src/HomelabBot/Services/KernelService.cs
+++ b/src/HomelabBot/Services/KernelService.cs
@@ -230,8 +230,9 @@ public sealed class KernelService
             activity?.SetTag("langfuse.trace.output", title);
             return title;
         }
-        catch
+        catch (Exception ex)
         {
+            _logger.LogWarning(ex, "Title generation failed, defaulting to 'Chat'");
             return "Chat";
         }
     }

--- a/src/HomelabBot/Services/KnowledgeRefreshService.cs
+++ b/src/HomelabBot/Services/KnowledgeRefreshService.cs
@@ -41,12 +41,12 @@ public sealed class KnowledgeRefreshService : BackgroundService
             {
                 if (!_config.CurrentValue.Enabled)
                 {
-                    _logger.LogDebug("Knowledge refresh disabled, rechecking in 1 minute");
+                    _logger.LogInformation("Knowledge refresh disabled, rechecking in 1 minute");
                     await Task.Delay(TimeSpan.FromMinutes(1), stoppingToken);
                     continue;
                 }
 
-                var delay = ScheduleHelper.CalculateDelayUntilNextRun(_config.CurrentValue.ScheduleTime, _config.CurrentValue.TimeZone);
+                var delay = ScheduleHelper.CalculateDelayUntilNextRun(_config.CurrentValue.ScheduleTime, _config.CurrentValue.TimeZone, logger: _logger);
                 _logger.LogInformation("Next knowledge refresh in {Delay}", delay);
 
                 await Task.Delay(delay, stoppingToken);

--- a/src/HomelabBot/Services/KnowledgeService.cs
+++ b/src/HomelabBot/Services/KnowledgeService.cs
@@ -54,7 +54,7 @@ public sealed class KnowledgeService
 
         db.Knowledge.Add(knowledge);
         await db.SaveChangesAsync();
-        _logger.LogDebug("Remembered: [{Topic}] {Fact}", topic, fact);
+        _logger.LogInformation("Remembered: [{Topic}] {Fact}", topic, fact);
         return knowledge;
     }
 

--- a/src/HomelabBot/Services/LangfuseEnrichmentProcessor.cs
+++ b/src/HomelabBot/Services/LangfuseEnrichmentProcessor.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Text.Json;
+using Microsoft.Extensions.Logging;
 using OpenTelemetry;
 
 namespace HomelabBot.Services;
@@ -11,59 +12,70 @@ namespace HomelabBot.Services;
 /// </summary>
 public sealed class LangfuseEnrichmentProcessor : BaseProcessor<Activity>
 {
+    private readonly ILogger<LangfuseEnrichmentProcessor> _logger;
+
+    public LangfuseEnrichmentProcessor(ILoggerFactory loggerFactory)
+    {
+        _logger = loggerFactory.CreateLogger<LangfuseEnrichmentProcessor>();
+    }
+
     public override void OnEnd(Activity activity)
     {
-        PropagateFromParent(activity, "langfuse.session.id");
-        PropagateFromParent(activity, "langfuse.user.id");
-
-        // Our custom traces and spans (Chat, Generate Title, SmartRecall, etc.)
-        if (activity.Source.Name == "HomelabBot.Chat")
+        try
         {
-            // Root trace level
-            CopyTag(activity, "langfuse.trace.input", "input.value");
-            CopyTag(activity, "langfuse.trace.output", "output.value");
+            PropagateFromParent(activity, "langfuse.session.id");
+            PropagateFromParent(activity, "langfuse.user.id");
 
-            // Child span level - map to observation for Input/Output preview
-            CopyTag(activity, "langfuse.span.input", "langfuse.observation.input");
-            CopyTag(activity, "langfuse.span.output", "langfuse.observation.output");
-            return;
+            // Our custom traces and spans (Chat, Generate Title, SmartRecall, etc.)
+            if (activity.Source.Name == "HomelabBot.Chat")
+            {
+                // Root trace level
+                CopyTag(activity, "langfuse.trace.input", "input.value");
+                CopyTag(activity, "langfuse.trace.output", "output.value");
+
+                // Child span level - map to observation for Input/Output preview
+                CopyTag(activity, "langfuse.span.input", "langfuse.observation.input");
+                CopyTag(activity, "langfuse.span.output", "langfuse.observation.output");
+            }
+            else if (activity.Source.Name.StartsWith("Microsoft.SemanticKernel"))
+            {
+                var operation = activity.GetTagItem("gen_ai.operation.name")?.ToString();
+
+                if (operation == "execute_tool")
+                {
+                    // Tool call - extract arguments and result
+                    var args = ExtractToolContent(activity, "gen_ai.tool.message");
+                    if (!string.IsNullOrEmpty(args))
+                    {
+                        activity.SetTag("langfuse.observation.input", args);
+                    }
+
+                    var result = ExtractToolContent(activity, "gen_ai.tool.result");
+                    if (!string.IsNullOrEmpty(result))
+                    {
+                        activity.SetTag("langfuse.observation.output", result);
+                    }
+                }
+                else
+                {
+                    // Chat generation - extract user message and response
+                    var input = ExtractContent(activity, "gen_ai.user.message");
+                    if (!string.IsNullOrEmpty(input))
+                    {
+                        activity.SetTag("langfuse.observation.input", input);
+                    }
+
+                    var output = ExtractContent(activity, "gen_ai.choice");
+                    if (!string.IsNullOrEmpty(output))
+                    {
+                        activity.SetTag("langfuse.observation.output", output);
+                    }
+                }
+            }
         }
-
-        // SK spans - extract content for clean Langfuse preview
-        if (activity.Source.Name.StartsWith("Microsoft.SemanticKernel"))
+        catch (Exception ex)
         {
-            var operation = activity.GetTagItem("gen_ai.operation.name")?.ToString();
-
-            if (operation == "execute_tool")
-            {
-                // Tool call - extract arguments and result
-                var args = ExtractToolContent(activity, "gen_ai.tool.message");
-                if (!string.IsNullOrEmpty(args))
-                {
-                    activity.SetTag("langfuse.observation.input", args);
-                }
-
-                var result = ExtractToolContent(activity, "gen_ai.tool.result");
-                if (!string.IsNullOrEmpty(result))
-                {
-                    activity.SetTag("langfuse.observation.output", result);
-                }
-            }
-            else
-            {
-                // Chat generation - extract user message and response
-                var input = ExtractContent(activity, "gen_ai.user.message");
-                if (!string.IsNullOrEmpty(input))
-                {
-                    activity.SetTag("langfuse.observation.input", input);
-                }
-
-                var output = ExtractContent(activity, "gen_ai.choice");
-                if (!string.IsNullOrEmpty(output))
-                {
-                    activity.SetTag("langfuse.observation.output", output);
-                }
-            }
+            _logger.LogError(ex, "Error enriching span {ActivityName} for Langfuse", activity.DisplayName);
         }
 
         base.OnEnd(activity);
@@ -131,7 +143,7 @@ public sealed class LangfuseEnrichmentProcessor : BaseProcessor<Activity>
                         lastContent = mc.GetString();
                     }
                 }
-                catch
+                catch (JsonException)
                 {
                     lastContent = json;
                 }
@@ -182,7 +194,7 @@ public sealed class LangfuseEnrichmentProcessor : BaseProcessor<Activity>
                     // Fallback to full JSON
                     return json;
                 }
-                catch
+                catch (JsonException)
                 {
                     return json;
                 }

--- a/src/HomelabBot/Services/LogAnomalyService.cs
+++ b/src/HomelabBot/Services/LogAnomalyService.cs
@@ -57,7 +57,7 @@ public sealed class LogAnomalyService : ScheduledBackgroundService
 
         if (!hasCritical && newSpikes.Count == 0)
         {
-            _logger.LogDebug("No log anomalies detected");
+            _logger.LogInformation("No log anomalies detected");
             return;
         }
 

--- a/src/HomelabBot/Services/PrometheusQueryService.cs
+++ b/src/HomelabBot/Services/PrometheusQueryService.cs
@@ -31,7 +31,7 @@ public sealed class PrometheusQueryService
 
             if (!response.IsSuccessStatusCode)
             {
-                _logger.LogDebug("Prometheus query failed with {Status}: {Query}",
+                _logger.LogWarning("Prometheus query failed with {Status}: {Query}",
                     response.StatusCode, query);
                 return null;
             }
@@ -52,7 +52,7 @@ public sealed class PrometheusQueryService
         }
         catch (Exception ex)
         {
-            _logger.LogDebug(ex, "Failed to query Prometheus: {Query}", query);
+            _logger.LogWarning(ex, "Failed to query Prometheus: {Query}", query);
             return null;
         }
     }
@@ -70,7 +70,7 @@ public sealed class PrometheusQueryService
         }
         catch (Exception ex)
         {
-            _logger.LogDebug(ex, "Failed to query Prometheus: {Query}", query);
+            _logger.LogWarning(ex, "Failed to query Prometheus: {Query}", query);
             return null;
         }
     }
@@ -109,7 +109,7 @@ public sealed class PrometheusQueryService
         }
         catch (Exception ex)
         {
-            _logger.LogDebug(ex, "Failed to query Prometheus multiple: {Query}", query);
+            _logger.LogWarning(ex, "Failed to query Prometheus multiple: {Query}", query);
         }
 
         return results;
@@ -134,7 +134,7 @@ public sealed class PrometheusQueryService
         }
         catch (Exception ex)
         {
-            _logger.LogDebug(ex, "Failed to get Prometheus targets");
+            _logger.LogWarning(ex, "Failed to get Prometheus targets");
             return [];
         }
     }
@@ -153,7 +153,7 @@ public sealed class PrometheusQueryService
         }
         catch (Exception ex)
         {
-            _logger.LogDebug(ex, "Failed to query Prometheus range: {Query}", query);
+            _logger.LogWarning(ex, "Failed to query Prometheus range: {Query}", query);
             return null;
         }
     }
@@ -171,7 +171,7 @@ public sealed class PrometheusQueryService
         }
         catch (Exception ex)
         {
-            _logger.LogDebug(ex, "Failed to get label values for {Label}", label);
+            _logger.LogWarning(ex, "Failed to get label values for {Label}", label);
             return null;
         }
     }

--- a/src/HomelabBot/Services/RemediationService.cs
+++ b/src/HomelabBot/Services/RemediationService.cs
@@ -1,5 +1,6 @@
 using HomelabBot.Data.Entities;
 using HomelabBot.Models;
+using Microsoft.Extensions.Logging;
 
 namespace HomelabBot.Services;
 
@@ -10,28 +11,34 @@ public sealed class RemediationService
     private readonly AutoRemediationService _autoRemediation;
     private readonly IncidentSimilarityService _similarityService;
     private readonly HealingChainService _healingChain;
+    private readonly ILogger<RemediationService> _logger;
 
     public RemediationService(
         RunbookTriggerService runbookTrigger,
         InvestigationService memoryService,
         AutoRemediationService autoRemediation,
         IncidentSimilarityService similarityService,
-        HealingChainService healingChain)
+        HealingChainService healingChain,
+        ILogger<RemediationService> logger)
     {
         _runbookTrigger = runbookTrigger;
         _memoryService = memoryService;
         _autoRemediation = autoRemediation;
         _similarityService = similarityService;
         _healingChain = healingChain;
+        _logger = logger;
     }
 
     public async Task<RemediationOutcome> TryRemediateAsync(
         AlertmanagerWebhookAlert alert, CancellationToken ct)
     {
+        _logger.LogInformation("Attempting remediation for alert {AlertName}", alert.AlertName);
+
         // 1. Try runbook match — fastest, no LLM needed
         var runbookResult = await _runbookTrigger.TryMatchAndExecuteAsync(alert, ct);
         if (runbookResult != null)
         {
+            _logger.LogInformation("Remediation for {AlertName}: runbook matched", alert.AlertName);
             return new RemediationOutcome
             {
                 Message = runbookResult,
@@ -50,6 +57,8 @@ public sealed class RemediationService
         var remResult = await _autoRemediation.TryAutoRemediateAsync(alert, matchedRunbooks, ct);
         if (remResult is { WasAutoExecuted: true } or { NeedsConfirmation: true })
         {
+            _logger.LogInformation("Remediation for {AlertName}: auto-remediation {Outcome}",
+                alert.AlertName, remResult.WasAutoExecuted ? "executed" : "needs confirmation");
             return new RemediationOutcome
             {
                 Message = remResult.Message,
@@ -72,6 +81,7 @@ public sealed class RemediationService
             searchTerms, containerName, ct, similarIncidents);
         if (chainResult is { Success: true })
         {
+            _logger.LogInformation("Remediation for {AlertName}: healing chain succeeded", alert.AlertName);
             return new RemediationOutcome
             {
                 Message = chainResult.Message,
@@ -85,6 +95,7 @@ public sealed class RemediationService
         }
 
         // 6. Nothing handled — return context for LLM investigation fallback
+        _logger.LogInformation("Remediation for {AlertName}: no strategy handled, falling back to LLM", alert.AlertName);
         return new RemediationOutcome
         {
             Message = string.Empty,

--- a/src/HomelabBot/Services/RunbookTriggerService.cs
+++ b/src/HomelabBot/Services/RunbookTriggerService.cs
@@ -45,6 +45,7 @@ public sealed class RunbookTriggerService
 
         if (matched == null)
         {
+            _logger.LogInformation("No runbook matched alert {AlertName}", alert.AlertName);
             return null;
         }
 
@@ -53,6 +54,7 @@ public sealed class RunbookTriggerService
 
         if (matched.TrustLevel == TrustLevel.Risky)
         {
+            _logger.LogWarning("Runbook '{RunbookName}' matched {AlertName} but requires confirmation", matched.Name, alert.AlertName);
             return $"📋 Runbook **{matched.Name}** matched this alert but requires manual confirmation (TrustLevel=Risky). " +
                    $"Use the bot to run: `execute runbook {matched.Id}`";
         }

--- a/src/HomelabBot/Services/ScheduleHelper.cs
+++ b/src/HomelabBot/Services/ScheduleHelper.cs
@@ -1,26 +1,26 @@
+using Microsoft.Extensions.Logging;
+
 namespace HomelabBot.Services;
 
 public static class ScheduleHelper
 {
     public static TimeSpan CalculateDelayUntilNextRun(
-        string scheduleTime, string timeZone, DayOfWeek? scheduleDay = null)
+        string scheduleTime, string timeZone, DayOfWeek? scheduleDay = null, ILogger? logger = null)
     {
         TimeZoneInfo tz;
         try
         {
             tz = TimeZoneInfo.FindSystemTimeZoneById(timeZone);
         }
-        catch (TimeZoneNotFoundException)
+        catch (Exception ex) when (ex is TimeZoneNotFoundException or InvalidTimeZoneException)
         {
-            tz = TimeZoneInfo.Utc;
-        }
-        catch (InvalidTimeZoneException)
-        {
+            logger?.LogWarning("Unknown/invalid timezone {TimeZone}, falling back to UTC", timeZone);
             tz = TimeZoneInfo.Utc;
         }
 
         if (!TimeOnly.TryParse(scheduleTime, out var parsedTime))
         {
+            logger?.LogWarning("Failed to parse schedule time {ScheduleTime}, defaulting to 08:00", scheduleTime);
             parsedTime = new TimeOnly(8, 0);
         }
 

--- a/src/HomelabBot/Services/ScheduledBackgroundService.cs
+++ b/src/HomelabBot/Services/ScheduledBackgroundService.cs
@@ -35,13 +35,13 @@ public abstract class ScheduledBackgroundService : BackgroundService
             {
                 if (!IsEnabled)
                 {
-                    Logger.LogDebug("{Service} disabled, rechecking in 1 minute", GetType().Name);
+                    Logger.LogInformation("{Service} disabled, rechecking in 1 minute", GetType().Name);
                     await Task.Delay(TimeSpan.FromMinutes(1), stoppingToken);
                     continue;
                 }
 
                 var delay = GetDelay();
-                Logger.LogDebug("{Service} next run in {Delay}", GetType().Name, delay);
+                Logger.LogInformation("{Service} next run in {Delay}", GetType().Name, delay);
                 await Task.Delay(delay, stoppingToken);
 
                 await RunIterationAsync(stoppingToken);

--- a/src/HomelabBot/Services/SecurityAuditService.cs
+++ b/src/HomelabBot/Services/SecurityAuditService.cs
@@ -29,7 +29,7 @@ public sealed class SecurityAuditService : ScheduledBackgroundService
     protected override ILogger Logger => _logger;
 
     protected override TimeSpan GetDelay() =>
-        ScheduleHelper.CalculateDelayUntilNextRun(_config.CurrentValue.ScheduleTime, _config.CurrentValue.TimeZone, _config.CurrentValue.ScheduleDay);
+        ScheduleHelper.CalculateDelayUntilNextRun(_config.CurrentValue.ScheduleTime, _config.CurrentValue.TimeZone, _config.CurrentValue.ScheduleDay, _logger);
 
     protected override Task RunIterationAsync(CancellationToken ct) => RunAuditAndDeliverAsync(ct);
 
@@ -39,6 +39,7 @@ public sealed class SecurityAuditService : ScheduledBackgroundService
 
         try
         {
+            _logger.LogInformation("Running security audit");
             var report = await _kernelService.ProcessMessageAsync(
                 threadId: threadId,
                 userMessage: SecurityAuditPrompts.Investigation,
@@ -47,6 +48,7 @@ public sealed class SecurityAuditService : ScheduledBackgroundService
                 systemPromptOverride: SecurityAuditPrompts.System,
                 ct: ct);
 
+            _logger.LogInformation("Security audit completed, report length: {Length}", report.Length);
             return report;
         }
         finally

--- a/src/HomelabBot/Services/ServiceStateStore.cs
+++ b/src/HomelabBot/Services/ServiceStateStore.cs
@@ -1,16 +1,19 @@
 using HomelabBot.Data;
 using HomelabBot.Data.Entities;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 
 namespace HomelabBot.Services;
 
 public class ServiceStateStore
 {
     private readonly IDbContextFactory<HomelabDbContext> _dbFactory;
+    private readonly ILogger<ServiceStateStore> _logger;
 
-    public ServiceStateStore(IDbContextFactory<HomelabDbContext> dbFactory)
+    public ServiceStateStore(IDbContextFactory<HomelabDbContext> dbFactory, ILogger<ServiceStateStore> logger)
     {
         _dbFactory = dbFactory;
+        _logger = logger;
     }
 
     public virtual async Task<string?> GetAsync(string serviceName, string key)
@@ -18,6 +21,8 @@ public class ServiceStateStore
         await using var db = await _dbFactory.CreateDbContextAsync();
         var entry = await db.ServiceStates
             .FirstOrDefaultAsync(s => s.ServiceName == serviceName && s.Key == key);
+
+        _logger.LogInformation("State {ServiceName}/{Key}: {Result}", serviceName, key, entry is null ? "not found" : "found");
         return entry?.Value;
     }
 
@@ -42,6 +47,15 @@ public class ServiceStateStore
             });
         }
 
-        await db.SaveChangesAsync();
+        try
+        {
+            await db.SaveChangesAsync();
+            _logger.LogInformation("{Operation} state for {ServiceName}/{Key}", entry != null ? "Updated" : "Created", serviceName, key);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to save state for {ServiceName}/{Key}", serviceName, key);
+            throw;
+        }
     }
 }

--- a/src/HomelabBot/Services/SummaryDataAggregator.cs
+++ b/src/HomelabBot/Services/SummaryDataAggregator.cs
@@ -29,7 +29,7 @@ public sealed class SummaryDataAggregator
 
     public async Task<DailySummaryData> AggregateAsync(CancellationToken ct = default)
     {
-        _logger.LogDebug("Starting data aggregation for daily summary");
+        _logger.LogInformation("Starting data aggregation for daily summary");
 
         var alertsTask = GetAlertsAsync(ct);
         var containersTask = GetContainersAsync(ct);
@@ -82,7 +82,7 @@ public sealed class SummaryDataAggregator
                 .DistinctBy(a => (a.Name, a.Instance))
                 .ToList();
 
-            _logger.LogDebug("Found {Count} alerts in the last 24h", alerts.Count);
+            _logger.LogInformation("Found {Count} alerts in the last 24h", alerts.Count);
             return alerts;
         }
         catch (Exception ex)

--- a/src/HomelabBot/Services/TelemetryChatClient.cs
+++ b/src/HomelabBot/Services/TelemetryChatClient.cs
@@ -60,7 +60,7 @@ public sealed class TelemetryChatClient : DelegatingChatClient
                     activity?.SetTag("langfuse.observation.input", argsPreview);
                 }
 
-                _logger.LogDebug("Anthropic tool call: {Tool}", content.Name);
+                _logger.LogInformation("Anthropic tool call: {Tool}", content.Name);
             }
 
             // Log tool results (tool → LLM)

--- a/src/HomelabBot/Services/TelemetryFunctionFilter.cs
+++ b/src/HomelabBot/Services/TelemetryFunctionFilter.cs
@@ -37,9 +37,9 @@ public sealed class TelemetryFunctionFilter : IFunctionInvocationFilter
                 argumentsJson = JsonSerializer.Serialize(
                     context.Arguments.ToDictionary(kvp => kvp.Key, kvp => kvp.Value?.ToString()));
             }
-            catch
+            catch (Exception ex)
             {
-                // Ignore serialization errors
+                _logger.LogWarning(ex, "Failed to serialize arguments for {Function}", context.Function.Name);
             }
         }
 
@@ -58,8 +58,9 @@ public sealed class TelemetryFunctionFilter : IFunctionInvocationFilter
                         ? str
                         : JsonSerializer.Serialize(resultValue);
                 }
-                catch
+                catch (Exception ex)
                 {
+                    _logger.LogWarning(ex, "Failed to serialize result for {Function}", context.Function.Name);
                     resultJson = resultValue.ToString();
                 }
             }

--- a/tests/HomelabBot.Tests/AutoRemediationServiceTests.cs
+++ b/tests/HomelabBot.Tests/AutoRemediationServiceTests.cs
@@ -21,7 +21,7 @@ public class AutoRemediationServiceTests : IClassFixture<DatabaseFixture>, IDisp
         _fixture = fixture;
         var dockerClient = new DockerClientConfiguration().CreateClient();
         _dockerPlugin = Substitute.For<DockerPlugin>(dockerClient, NullLogger<DockerPlugin>.Instance);
-        _stateStore = Substitute.For<ServiceStateStore>(_fixture.DbContextFactory);
+        _stateStore = Substitute.For<ServiceStateStore>(_fixture.DbContextFactory, NullLogger<ServiceStateStore>.Instance);
 
         // LoadStateAsync calls GetAsync twice during construction
         _stateStore.GetAsync(Arg.Any<string>(), Arg.Any<string>())

--- a/tests/HomelabBot.Tests/ServiceStateStoreTests.cs
+++ b/tests/HomelabBot.Tests/ServiceStateStoreTests.cs
@@ -1,4 +1,5 @@
 using HomelabBot.Services;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace HomelabBot.Tests;
 
@@ -8,7 +9,7 @@ public class ServiceStateStoreTests : IClassFixture<DatabaseFixture>
 
     public ServiceStateStoreTests(DatabaseFixture fixture)
     {
-        _store = new ServiceStateStore(fixture.DbContextFactory);
+        _store = new ServiceStateStore(fixture.DbContextFactory, NullLogger<ServiceStateStore>.Instance);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Inject `ILogger` into 8 files that had none (ServiceStateStore, 4 controllers, McpApiKeyMiddleware, RemediationService, LangfuseEnrichmentProcessor)
- Fix all silent catch blocks project-wide (zero bare catches remaining)
- Upgrade all `LogDebug` to `LogInformation`/`LogWarning` (zero LogDebug remaining)
- Add decision-point logging to remediation pipeline, alert processing, healing chains
- Narrow JSON parse catches to `JsonException` in LangfuseEnrichmentProcessor
- Fix `base.OnEnd()` always being called in LangfuseEnrichmentProcessor
- Pass logger to ScheduleHelper from all callers

## Test plan
- [x] `dotnet build` compiles clean
- [x] `dotnet test` — 136 tests pass in ~600ms
- [x] Zero `LogDebug` remaining in src/
- [x] Zero bare `catch` blocks remaining in src/
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)