### PR TITLE
Add missing migration for WarRoom FK columns

### DIFF
--- a/src/HomelabBot/Data/Migrations/20260404160513_RemoveDeadWarRoomFKs.Designer.cs
+++ b/src/HomelabBot/Data/Migrations/20260404160513_RemoveDeadWarRoomFKs.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using HomelabBot.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace HomelabBot.Data.Migrations
 {
     [DbContext(typeof(HomelabDbContext))]
-    partial class HomelabDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260404160513_RemoveDeadWarRoomFKs")]
+    partial class RemoveDeadWarRoomFKs
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.1");

--- a/src/HomelabBot/Data/Migrations/20260404160513_RemoveDeadWarRoomFKs.cs
+++ b/src/HomelabBot/Data/Migrations/20260404160513_RemoveDeadWarRoomFKs.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace HomelabBot.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class RemoveDeadWarRoomFKs : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "HealingChainId",
+                table: "WarRooms");
+
+            migrationBuilder.DropColumn(
+                name: "InvestigationId",
+                table: "WarRooms");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "HealingChainId",
+                table: "WarRooms",
+                type: "INTEGER",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "InvestigationId",
+                table: "WarRooms",
+                type: "INTEGER",
+                nullable: true);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- PR #95 removed `HealingChainId` and `InvestigationId` from `WarRoom` entity but didn't generate a migration
- EF Core's `PendingModelChangesWarning` causes crash on startup (bot is crash-looping in prod)
- This adds the missing migration to drop those dead columns

## Test plan
- [x] `dotnet test` — 136 tests pass
- [x] `dotnet ef migrations has-pending-model-changes` — no longer reports changes
- [ ] Bot stops crash-looping after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)