### PR TITLE
Switch bot LLM to Claude Sonnet 5

### DIFF
--- a/src/HomelabBot/Configuration/BotConfiguration.cs
+++ b/src/HomelabBot/Configuration/BotConfiguration.cs
@@ -17,7 +17,7 @@ public sealed class BotConfiguration
 
     public required string OpenRouterApiKey { get; init; }
 
-    public string OpenRouterModel { get; init; } = "anthropic/claude-sonnet-4.6";
+    public string OpenRouterModel { get; init; } = "anthropic/claude-sonnet-5";
 
     public string OpenRouterEndpoint { get; init; } = "https://openrouter.ai/api/v1";
 

--- a/src/HomelabBot/appsettings.json
+++ b/src/HomelabBot/appsettings.json
@@ -27,7 +27,7 @@
   "Bot": {
     "DiscordToken": "",
     "OpenRouterApiKey": "",
-    "OpenRouterModel": "anthropic/claude-sonnet-4.6",
+    "OpenRouterModel": "anthropic/claude-sonnet-5",
     "OpenRouterEndpoint": "https://openrouter.ai/api/v1",
     "MaxResponseAttempts": 3,
     "MaxTokens": 50000,


### PR DESCRIPTION
Bumps `OpenRouterModel` from `anthropic/claude-sonnet-4.6` to `anthropic/claude-sonnet-5` in `appsettings.json` and the `BotConfiguration` default. Slug verified against the OpenRouter models API.

No other changes — retry/empty-response handling and `MaxTokens` stay as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)