### PR TITLE
Only auto-reply in threads the bot created

### DIFF
--- a/src/HomelabBot/Services/DiscordBotService.cs
+++ b/src/HomelabBot/Services/DiscordBotService.cs
@@ -365,10 +365,16 @@ public sealed class DiscordBotService : BackgroundService
         // Check if we should respond
         var isMentioned = e.Message.MentionedUsers.Any(u => u.Id == client.CurrentUser.Id);
         var isDedicatedChannel = _config.DedicatedChannels.Contains(e.Channel.Id);
-        var isThread = e.Channel.IsThread;
 
-        // Respond in: mentions anywhere, dedicated channels, or threads we're already in
-        if (!isMentioned && !isDedicatedChannel && !isThread)
+        // Only treat a thread as "ours" if the bot created it (mention-spawned
+        // conversation threads and war rooms). Threads created by other bots or
+        // users — e.g. the owner chatting with a different bot — must not trigger
+        // us unless we're explicitly mentioned.
+        var isOwnThread = e.Channel is DiscordThreadChannel threadChannel
+            && threadChannel.CreatorId == client.CurrentUser.Id;
+
+        // Respond in: mentions anywhere, dedicated channels, or threads we created
+        if (!isMentioned && !isDedicatedChannel && !isOwnThread)
         {
             return;
         }


### PR DESCRIPTION
## Problem
homelab-bot replied in **every** thread it could see, because the response gate treated `e.Channel.IsThread` as "a thread we're already in." So when the owner chats with a different bot (e.g. devtuś) inside a thread, homelab-bot butts in even though it was never addressed.

## Fix
Gate non-mention thread replies on `DiscordThreadChannel.CreatorId == bot`. The bot now auto-replies without a mention **only in threads it created**:
- mention-spawned conversation threads (created via `e.Message.CreateThreadAsync`) ✅
- war-room threads (created via `CreateThreadInChannelAsync` → `CreateThreadAsync`) ✅
- threads created by other bots/users → silent unless explicitly @mentioned ✅

Mentions and dedicated channels are unaffected. No DB or intent changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)